### PR TITLE
Renew session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  helper_method :current_user, :current_user?, :patron, :symphony_client
+  helper_method :current_user, :current_user?, :patron, :renew_session_token, :symphony_client
 
   def current_user
     session_data = request.env['warden'].user
@@ -18,6 +18,12 @@ class ApplicationController < ActionController::Base
     return unless current_user?
 
     @patron ||= Patron.new(patron_info_response)
+  end
+
+  def renew_session_token
+    request.env['warden'].logout
+
+    redirect_to Settings.symws.webaccess_url + request.base_url
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
 
   def current_user
     session_data = request.env['warden'].user
+    # Assuming the && is used solely to guard against nil. A new User is minted with every request based upon details
+    # Warden set in the session data in cookies. So, new user every request, same SWS session data.
     session_data && User.new(session_data)
   end
 

--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -10,15 +10,6 @@ class SummariesController < ApplicationController
   def index
     @patron = patron
 
-    if stale?
-      request.env['warden'].logout
-      redirect_to Settings.symws.webaccess_url + request.base_url
-    end
+    renew_session_token if @patron.stale?
   end
-
-  private
-
-    def stale?
-      patron.record == { 'messageList' => [{ 'code' => 'sessionTimedOut', 'message' => 'The session has timed out.' }] }
-    end
 end

--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -9,5 +9,16 @@ class SummariesController < ApplicationController
   # GET /summaries.json
   def index
     @patron = patron
+
+    if stale?
+      request.env['warden'].logout
+      redirect_to Settings.symws.webaccess_url + request.base_url
+    end
   end
+
+  private
+
+    def stale?
+      patron.record == { 'messageList' => [{ 'code' => 'sessionTimedOut', 'message' => 'The session has timed out.' }] }
+    end
 end

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -36,6 +36,10 @@ class Patron
     @holds ||= fields['holdRecordList'].map { |hold| Hold.new(hold) }
   end
 
+  def stale?
+    record == { 'messageList' => [{ 'code' => 'sessionTimedOut', 'message' => 'The session has timed out.' }] }
+  end
+
   private
 
     def fields

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,5 @@
 symws:
+  webaccess_url: https://example.com/webaccess
   url: https://example.com/symwsbc
   headers:
       x_sirs_clientID: SymWSTestClient

--- a/spec/controllers/summaries_controller_spec.rb
+++ b/spec/controllers/summaries_controller_spec.rb
@@ -40,5 +40,23 @@ RSpec.describe SummariesController do
     it 'redirects to the home page' do
       expect(get(:index)).to render_template 'index'
     end
+
+    context 'with a stale session' do
+      let(:patron) { instance_double(Patron) }
+      let(:mock_patron_response) { { 'messageList' => [{
+        'code' => 'sessionTimedOut',
+        'message' => 'The session has timed out.'
+      }] } }
+
+      before do
+        allow(Patron).to receive(:new).and_return(patron)
+        allow(patron).to receive(:record).and_return(mock_patron_response)
+      end
+
+      it 'redirects to the application authentication mechanism' do
+        get(:index)
+        expect(response).to have_http_status '302'
+      end
+    end
   end
 end

--- a/spec/controllers/summaries_controller_spec.rb
+++ b/spec/controllers/summaries_controller_spec.rb
@@ -43,14 +43,10 @@ RSpec.describe SummariesController do
 
     context 'with a stale session' do
       let(:patron) { instance_double(Patron) }
-      let(:mock_patron_response) { { 'messageList' => [{
-        'code' => 'sessionTimedOut',
-        'message' => 'The session has timed out.'
-      }] } }
 
       before do
         allow(Patron).to receive(:new).and_return(patron)
-        allow(patron).to receive(:record).and_return(mock_patron_response)
+        allow(patron).to receive(:stale?).and_return(true)
       end
 
       it 'redirects to the application authentication mechanism' do

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe Patron do
-  subject(:patron) do
-    described_class.new(
-      {
-        key: '1',
-        fields: fields
-      }.with_indifferent_access
-    )
+  subject(:patron) { described_class.new(record) }
+
+  let(:record) do
+    {
+      key: '1',
+      fields: fields
+    }.with_indifferent_access
   end
 
   let(:fields) do
@@ -40,6 +40,10 @@ RSpec.describe Patron do
     expect(patron.barcode).to eq '1234'
   end
 
+  it 'has a valid session' do
+    expect(patron).not_to be_stale
+  end
+
   context 'with checkouts' do
     before do
       fields[:circRecordList] = [{ key: 1, fields: {} }]
@@ -61,6 +65,18 @@ RSpec.describe Patron do
       it 'returns a list of holds for the patron' do
         expect(patron.holds).to include a_kind_of(Hold).and(have_attributes(key: 1))
       end
+    end
+  end
+
+  context 'with a stale session' do
+    let(:record) do
+      {
+        'messageList' => [{ 'code' => 'sessionTimedOut', 'message' => 'The session has timed out.' }]
+      }
+    end
+
+    it 'has a stale patron session token' do
+      expect(patron).to be_stale
     end
   end
 end


### PR DESCRIPTION
#24 

I left the `#logout` on `SessionsController`. I figured we may actually want to keep it around either because we will present this to our users as an option for logging out OR for our own local dev purposes? Not sure.

Also, please do look for another way of doing this! I'm all ears.

Lastly, in order to simulate an invalid session you can throw a byebug/pry on `ApplicationController#current_user` and set a bad patronKey like 

`[1] pry(#<SessionsController>)> session_data['session_token'] = '83838'`

And that will invalidate the session.

## Additional change

Adds a comment on session/user management.