### PR TITLE
Adds a dependabot watcher config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "monthly"
+    default_assignees:
+      - "banukutlu"
+      - "cdmo"
+
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"
+    default_assignees:
+      - "banukutlu"
+      - "cdmo"


### PR DESCRIPTION
Just an experiment, see https://dependabot.com/docs/config-file/

You can tell dependabot to make PRs to update your dependencies. I set it to monthly so it wouldn't be overly annoying. IDK, what do you think?