### PR TITLE
Makes routes more specific, exact

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@
 Rails.application.routes.draw do
   root to: 'sessions#index'
 
-  resources :summaries, :fines, :checkouts, :holds
-  resources :renewals, only: :create
+  resources :summaries, :fines, :checkouts, only: [:index]
+  resources :renewals, only: [:create]
+  resources :holds, only: [:index, :update, :destroy]
 
   get '/logout', to: 'sessions#destroy', as: :logout
 end


### PR DESCRIPTION
Otherwise accessing, for example `summaries/new` gives a misleading error.