### PR TITLE
Adds Phusion Passenger to be used specifically in local development t…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'passenger', '>= 5.3.2', require: 'phusion_passenger/rack_handler'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,9 @@ GEM
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    passenger (6.0.4)
+      rack
+      rake (>= 0.8.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -358,6 +361,7 @@ DEPENDENCIES
   http (~> 4.0)
   listen (>= 3.0.5, < 3.2)
   niftany
+  passenger (>= 5.3.2)
   pry-byebug
   puma (~> 3.12)
   rails (~> 6.0.0)


### PR DESCRIPTION
…o more closely mirror production.

This is a drop in replacement for local puma. See this [Phusion Quickstart guide](https://www.phusionpassenger.com/docs/tutorials/quickstart/ruby/)

Not sure this is worth it honestly.

