### PR TITLE
redis for session (and cache)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ gem 'turbolinks', '~> 5'
 gem 'warden', '~> 1.2'
 gem 'webpacker', '~> 4.0'
 
+group :production do
+  gem 'hiredis'
+  gem 'redis'
+end
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile
+++ b/Gemfile
@@ -8,18 +8,15 @@ ruby '2.6.5'
 gem 'actionview-component'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'config', '~> 2.0'
+gem 'hiredis'
 gem 'http', '~> 4.0'
 gem 'puma', '~> 3.12'
 gem 'rails', '~> 6.0.0'
+gem 'redis'
 gem 'simplecov', require: false, group: :test
 gem 'turbolinks', '~> 5'
 gem 'warden', '~> 1.2'
 gem 'webpacker', '~> 4.0'
-
-group :production do
-  gem 'hiredis'
-  gem 'redis'
-end
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.0)
+    hiredis (0.6.3)
     html_tokenizer (0.0.7)
     http (4.2.0)
       addressable (~> 2.3)
@@ -247,6 +248,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.3)
     regexp_parser (1.6.0)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
@@ -355,6 +357,7 @@ DEPENDENCIES
   capybara
   config (~> 2.0)
   factory_bot_rails
+  hiredis
   http (~> 4.0)
   listen (>= 3.0.5, < 3.2)
   niftany
@@ -362,6 +365,7 @@ DEPENDENCIES
   puma (~> 3.12)
   rails (~> 6.0.0)
   rails-controller-testing
+  redis
   rspec-rails (~> 4.0.0.beta2)
   selenium-webdriver
   simplecov

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
 |----------|------|
 | `ruby`    |  2.6.5 <br> (_ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin18]_) |
 | `rails`   |  6.0.1 |
+| `redis`   | 5.0.7 |
 
 # Development Setup
+
 1.  [Make sure you have ssh keys established on your machine](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#generating-a-new-ssh-key)
 1.  Clone the application and install:
     ``` 
@@ -34,3 +36,22 @@
       headers: {}
     ```
     
+## Redis locally
+
+Use the [redis docker image](https://hub.docker.com/_/redis/).
+
+Should be able to just run it with a command listed int he docker hub page:
+
+`docker run --name some-redis -d redis`
+
+Then boot up the rails server and you'll be all set. Monitor the behavior by tailing the logs:
+
+`docker exec -it redis1 redis-cli monitor`
+
+# Terminology/"Ubiquitous Language"
+
+There is a lot of domain terminology that can be confusing. Here are some of the bigger things to keep in mind:
+
+* _Bib_ - a bibliographic container that holds calls and items, contains global information about the bibliographic record described like author and title which is the same throughout the entire record (p.s., bibs can be *large*).
+* _Call_ - a call number based container that contains items and is contained within a bib. There can be multiple calls in a bib. There can be multiple items in a call. 
+* _Item_ - info that describes the thing thing that is actually held or checked out. Has a barcode and check out status.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ There is a lot of domain terminology that can be confusing. Here are some of the
 
 * _Bib_ - a bibliographic container that holds calls and items, contains global information about the bibliographic record described like author and title which is the same throughout the entire record (p.s., bibs can be *large*).
 * _Call_ - a call number based container that contains items and is contained within a bib. There can be multiple calls in a bib. There can be multiple items in a call. 
-* _Item_ - info that describes the thing thing that is actually held or checked out. Has a barcode and check out status.
+* _Item_ - info that describes the thing that is actually held or checked out. Has a barcode and checkout status.
 
 This is an attempt at a quick and rough "[ubiquitous language](https://martinfowler.com/bliki/UbiquitousLanguage.html)"

--- a/README.md
+++ b/README.md
@@ -42,16 +42,34 @@ Use the [redis docker image](https://hub.docker.com/_/redis/).
 
 Should be able to just run it with a command listed int he docker hub page:
 
-`docker run --name some-redis -d redis`
+`docker run --name redis-the-new-black -d redis`
 
-Then boot up the rails server and you'll be all set. Monitor the behavior by tailing the logs:
+Then boot up the rails server with caching turned on and you'll be all set.
+ 
+ `bundle exec rails s --dev-caching`
+ 
+Monitor the behavior by tailing the logs:
 
-`docker exec -it redis1 redis-cli monitor`
+ `docker exec -it redis-the-new-black redis-cli monitor`
 
-# Terminology/"Ubiquitous Language"
+
+# Putting it all together
+
+Locally you'll need to run:
+
+```
+bundle exec rails s --dev-caching
+docker run --name redis-the-new-black -d redis
+bin/webpack-dev-server
+```
+
+Drop `--dev-caching` if it is getting in the way of dev work.
+
+# Terminology/"[Ubiquitous Language](https://martinfowler.com/bliki/UbiquitousLanguage.html)"
 
 There is a lot of domain terminology that can be confusing. Here are some of the bigger things to keep in mind:
 
 * _Bib_ - a bibliographic container that holds calls and items, contains global information about the bibliographic record described like author and title which is the same throughout the entire record (p.s., bibs can be *large*).
 * _Call_ - a call number based container that contains items and is contained within a bib. There can be multiple calls in a bib. There can be multiple items in a call. 
 * _Item_ - info that describes the thing thing that is actually held or checked out. Has a barcode and check out status.
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 Use the [redis docker image](https://hub.docker.com/_/redis/).
 
-Should be able to just run it with a command listed int he docker hub page:
+Should be able to just run it with a command listed in the docker hub page:
 
 `docker run --name redis-the-new-black -d redis`
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Monitor the behavior by tailing the logs:
  `docker exec -it redis-the-new-black redis-cli monitor`
 
 
-# Putting it all together
+## Putting it all together
 
 Locally you'll need to run:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use the [redis docker image](https://hub.docker.com/_/redis/).
 
 Should be able to just run it with a command listed in the docker hub page:
 
-`docker run --name redis-the-new-black -d redis`
+`docker run -d -p 6379:6379 --name redis-the-new-black redis:5.0.7`
 
 Then boot up the rails server with caching turned on and you'll be all set.
  

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bin/webpack-dev-server
 
 Drop `--dev-caching` if it is getting in the way of dev work.
 
-# Terminology/"[Ubiquitous Language](https://martinfowler.com/bliki/UbiquitousLanguage.html)"
+# Terminology
 
 There is a lot of domain terminology that can be confusing. Here are some of the bigger things to keep in mind:
 
@@ -73,3 +73,4 @@ There is a lot of domain terminology that can be confusing. Here are some of the
 * _Call_ - a call number based container that contains items and is contained within a bib. There can be multiple calls in a bib. There can be multiple items in a call. 
 * _Item_ - info that describes the thing thing that is actually held or checked out. Has a barcode and check out status.
 
+This is an attempt at a quick and rough "[ubiquitous language](https://martinfowler.com/bliki/UbiquitousLanguage.html)"

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,10 @@ module Myaccount
     config.middleware.use Warden::Manager do |manager|
       manager.default_strategies :library_id
     end
+
+    config.cache_store = :redis_cache_store, { url: 'redis://127.0.0.1:6379/1' }#ENV['REDIS_URL'] }
+    config.action_controller.perform_caching = true
+    config.session_store :cache_store, key: ENV['APP_SESSION_KEY']
+
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,9 +45,8 @@ module Myaccount
       manager.default_strategies :library_id
     end
 
-    config.cache_store = :redis_cache_store, { url: 'redis://127.0.0.1:6379/1' }#ENV['REDIS_URL'] }
+    config.cache_store = :redis_cache_store, { url: Settings.redis.url }
     config.action_controller.perform_caching = true
     config.session_store :cache_store, key: ENV['APP_SESSION_KEY']
-
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,6 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = true
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
@@ -37,7 +37,7 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/examp le.*/ ]
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -76,11 +76,11 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  # if ENV['RAILS_LOG_TO_STDOUT'].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  # end
+  end
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
@@ -105,8 +105,4 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-
-  config.cache_store = :redis_cache_store, { url: 'redis://127.0.0.1:6379/1' }#ENV['REDIS_URL'] }
-  config.action_controller.perform_caching = true
-  config.session_store :cache_store, key: ENV['APP_SESSION_KEY']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
@@ -37,7 +37,7 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/examp le.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -76,11 +76,11 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
+  # if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  # end
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
@@ -105,4 +105,8 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.cache_store = :redis_cache_store, { url: 'redis://127.0.0.1:6379/1' }#ENV['REDIS_URL'] }
+  config.action_controller.perform_caching = true
+  config.session_store :cache_store, key: ENV['APP_SESSION_KEY']
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,3 +3,5 @@ symws:
   url:
   headers: {}
 home_page_flash_message_html:
+redis:
+  url: 'redis://127.0.0.1:6379/1'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,4 +4,4 @@ symws:
   headers: {}
 home_page_flash_message_html:
 redis:
-  url: 'redis://127.0.0.1:6379/1'
+  url: <%= ENV.fetch 'REDIS_URL', 'redis://127.0.0.1:6379/1' %>


### PR DESCRIPTION
a little too easy to setup. More to come soon

Relevant:
`activesupport-6.0.1/lib/active_support/cache/redis_cache_store.rb`

## Additional changes

Added a "ubiquitous language" section (i.e., terminology)