### PR TITLE
Removes address1 from every request

### DIFF
--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -37,7 +37,6 @@ class SymphonyClient
                                      params: {
                                        includeFields: [
                                          '*',
-                                         'address1',
                                          *patron_linked_resources_fields(item_details)
                                        ].join(',')
                                      })


### PR DESCRIPTION
Very small change to the default patron info requested, because `address1` is only needed for the patron info page with the address on it, remove it from every request generically as it serves no purpose but adding a little weight.