### PR TITLE
Sidekiq on heroku with redis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,7 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/services/symphony_client_spec.rb'
+
+GlobalVars:
+  AllowedVariables:
+    - $REDIS_CLIENT

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,3 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/services/symphony_client_spec.rb'
-
-GlobalVars:
-  AllowedVariables:
-    - $REDIS_CLIENT

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bundle exec sidekiq -t 25 -c 2

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
-worker: bundle exec sidekiq -t 25 -c 2
+worker: bundle exec sidekiq -t 25

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
-worker: bundle exec sidekiq -t 25 -c 20
+worker: bundle exec sidekiq -t 25

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
-worker: bundle exec sidekiq -t 25
+worker: bundle exec sidekiq -t 25 -c 20

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
 worker: bundle exec sidekiq -t 25 -c 2

--- a/app/controllers/redis_jobs_controller.rb
+++ b/app/controllers/redis_jobs_controller.rb
@@ -4,12 +4,12 @@ class RedisJobsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def show
-    job_status = $REDIS_CLIENT.get(params[:id]) || { result: :not_found }
+    job_status = Redis.current.get(params[:id]) || { result: :not_found }
     render json: job_status
   end
 
   def destroy
-    status = $REDIS_CLIENT.del(params[:id]) || { result: :not_found }
+    status = Redis.current.del(params[:id]) || { result: :not_found }
     render json: status
   end
 end

--- a/app/controllers/redis_jobs_controller.rb
+++ b/app/controllers/redis_jobs_controller.rb
@@ -4,12 +4,12 @@ class RedisJobsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def show
-    job_status = Redis.new.get(params[:id]) || { result: :not_found }
+    job_status = $REDIS_CLIENT.get(params[:id]) || { result: :not_found }
     render json: job_status
   end
 
   def destroy
-    status = Redis.new.del(params[:id]) || { result: :not_found }
+    status = $REDIS_CLIENT.del(params[:id]) || { result: :not_found }
     render json: status
   end
 end

--- a/app/jobs/cancel_hold_job.rb
+++ b/app/jobs/cancel_hold_job.rb
@@ -10,7 +10,7 @@ class CancelHoldJob < ApplicationJob
 
     case response.status
     when 200
-      $REDIS_CLIENT.set("cancel_hold_#{hold_key}", {
+      Redis.current.set("cancel_hold_#{hold_key}", {
         hold_id: hold_key,
         result: :success
       }.to_json)
@@ -18,7 +18,7 @@ class CancelHoldJob < ApplicationJob
       error_message_raw = JSON.parse response.body
       error_message = error_message_raw&.dig('messageList')&.first&.dig('message') || 'Something went wrong'
       Sidekiq.logger.error("cancel_hold_#{hold_key}: #{error_message}")
-      $REDIS_CLIENT.set("cancel_hold_#{hold_key}", {
+      Redis.current.set("cancel_hold_#{hold_key}", {
         hold_id: hold_key,
         result: :failure,
         response: error_message

--- a/app/jobs/change_pickup_by_date_job.rb
+++ b/app/jobs/change_pickup_by_date_job.rb
@@ -14,7 +14,7 @@ class ChangePickupByDateJob < ApplicationJob
 
     case response.status
     when 200
-      $REDIS_CLIENT.set("pickup_by_date_#{hold_key}", {
+      Redis.current.set("pickup_by_date_#{hold_key}", {
         hold_id: hold_key,
         result: :success,
         new_value: pickup_by_date,
@@ -24,7 +24,7 @@ class ChangePickupByDateJob < ApplicationJob
       error_message_raw = JSON.parse response.body
       error_message = error_message_raw&.dig('messageList')&.first&.dig('message') || 'Something went wrong'
       Sidekiq.logger.error("pickup_by_date_#{hold_key}: #{error_message}")
-      $REDIS_CLIENT.set("pickup_by_date_#{hold_key}", {
+      Redis.current.set("pickup_by_date_#{hold_key}", {
         hold_id: hold_key,
         result: :failure,
         response: error_message

--- a/app/jobs/change_pickup_by_date_job.rb
+++ b/app/jobs/change_pickup_by_date_job.rb
@@ -18,7 +18,7 @@ class ChangePickupByDateJob < ApplicationJob
         hold_id: hold_key,
         result: :success,
         new_value: pickup_by_date,
-        new_value_formatted: Date.parse(pickup_by_date).strftime('%B %e, %Y')
+        new_value_formatted: Date.parse(pickup_by_date).strftime('%B %-d, %Y')
       }.to_json)
     else
       error_message_raw = JSON.parse response.body

--- a/app/jobs/change_pickup_library_job.rb
+++ b/app/jobs/change_pickup_library_job.rb
@@ -15,7 +15,7 @@ class ChangePickupLibraryJob < ApplicationJob
     case response.status
     when 200
       human_readable_location = Hold::PICKUP_LOCATION_ACTUAL[pickup_library.to_sym]
-      $REDIS_CLIENT.set("pickup_library_#{hold_key}", {
+      Redis.current.set("pickup_library_#{hold_key}", {
         hold_id: hold_key,
         result: :success,
         new_value: human_readable_location,
@@ -25,7 +25,7 @@ class ChangePickupLibraryJob < ApplicationJob
       error_message_raw = JSON.parse response.body
       error_message = error_message_raw&.dig('messageList')&.first&.dig('message') || 'Something went wrong'
       Sidekiq.logger.error("pickup_library_#{hold_key}: #{error_message}")
-      $REDIS_CLIENT.set("pickup_library_#{hold_key}", {
+      Redis.current.set("pickup_library_#{hold_key}", {
         hold_id: hold_key,
         result: :failure,
         response: error_message

--- a/app/jobs/view_holds_job.rb
+++ b/app/jobs/view_holds_job.rb
@@ -7,7 +7,6 @@ class ViewHoldsJob < ApplicationJob
 
   def perform(patron_key:, session_token:)
     symphony_client = SymphonyClient.new
-    @redis_client = Redis.new
     response = symphony_client.patron_info(patron_key: patron_key,
                                            session_token: session_token,
                                            item_details: { holdRecordList: true })
@@ -20,7 +19,7 @@ class ViewHoldsJob < ApplicationJob
     html = HoldsController.render template: 'holds/all', layout: false, locals: { holds_ready: holds_ready,
                                                                                   holds_not_ready: holds_not_ready }
     if response.present?
-      @redis_client.set("view_holds_#{patron_key}", {
+      $REDIS_CLIENT.set("view_holds_#{patron_key}", {
         result: :success,
         html: html
       }.to_json)
@@ -32,7 +31,7 @@ class ViewHoldsJob < ApplicationJob
 
     def process_failure(error_message:, patron_key:)
       Sidekiq.logger.error("view_holds_#{patron_key}: #{error_message}")
-      @redis_client.set("view_holds_#{patron_key}", {
+      $REDIS_CLIENT.set("view_holds_#{patron_key}", {
         result: :failure,
         response: error_message
       }.to_json)

--- a/app/jobs/view_holds_job.rb
+++ b/app/jobs/view_holds_job.rb
@@ -19,7 +19,7 @@ class ViewHoldsJob < ApplicationJob
     html = HoldsController.render template: 'holds/all', layout: false, locals: { holds_ready: holds_ready,
                                                                                   holds_not_ready: holds_not_ready }
     if response.present?
-      $REDIS_CLIENT.set("view_holds_#{patron_key}", {
+      Redis.current.set("view_holds_#{patron_key}", {
         result: :success,
         html: html
       }.to_json)
@@ -31,7 +31,7 @@ class ViewHoldsJob < ApplicationJob
 
     def process_failure(error_message:, patron_key:)
       Sidekiq.logger.error("view_holds_#{patron_key}: #{error_message}")
-      $REDIS_CLIENT.set("view_holds_#{patron_key}", {
+      Redis.current.set("view_holds_#{patron_key}", {
         result: :failure,
         response: error_message
       }.to_json)

--- a/app/models/concerns/bib_record.rb
+++ b/app/models/concerns/bib_record.rb
@@ -62,12 +62,10 @@ module BibRecord
 
     # Use Redis to store this globally once an hour
     def item_type_mapping
-      redis = Redis.new
-      return JSON.parse(redis.get('item_type_map')) unless redis.get('item_type_map').nil?
-
-      client = SymphonyClient.new
-      item_type_map = client.get_item_type_map.to_json
-      redis.setex('item_type_map', 3600, item_type_map)
-      JSON.parse(item_type_map)
+      Rails.cache.fetch(['item_type_map', __method__], expires_in: 60.minutes) do
+        client = SymphonyClient.new
+        item_type_map = client.get_item_type_map.to_json
+        JSON.parse(item_type_map)
+      end
     end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module Myaccount
       manager.default_strategies :library_id
     end
 
-    config.cache_store = :redis_cache_store, { url: Settings.redis.url }
+    config.cache_store = :redis_cache_store, { url: Settings.redis.cache.uri }
     config.action_controller.perform_caching = true
     config.session_store :cache_store, key: ENV['APP_SESSION_KEY']
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 $REDIS_CLIENT = Redis.new url: Settings.redis.database.uri

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+$REDIS_CLIENT = Redis.new url: Settings.redis.database.uri

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-$REDIS_CLIENT = Redis.new url: Settings.redis.database.uri
+Redis.current = Redis.new url: Settings.redis.database.uri

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,7 @@
 Sidekiq.configure_server do |config|
-  config.redis = { url: Settings.redis.sidekiq.uri }
+  config.redis = { url: Settings.redis.sidekiq.uri, size: 15 }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Settings.redis.sidekiq.uri }
+  config.redis = { url: Settings.redis.sidekiq.uri, size: 1 }
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Sidekiq.configure_server do |config|
   config.redis = { url: Settings.redis.sidekiq.uri, size: 15 }
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,5 +3,5 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Settings.redis.sidekiq.uri, size: 1 }
+  config.redis = { url: Settings.redis.sidekiq.uri, size: 2 }
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: Settings.redis.sidekiq.uri }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: Settings.redis.sidekiq.uri }
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,14 +27,14 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,7 +27,7 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch('WEB_CONCURRENCY') { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,5 @@ redis:
     uri: <%= ENV.fetch 'REDIS_SIDEKIQ_URL', 'redis://127.0.0.1:6379/1' %>
   cache:
     uri: <%= ENV.fetch 'REDIS_URL', 'redis://127.0.0.1:6379/1' %>
+  database:
+    uri: <%= ENV.fetch 'REDIS_DATABASE_URL', 'redis://127.0.0.1:6379/1' %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,4 +4,7 @@ symws:
   headers: {}
 home_page_flash_message_html:
 redis:
-  url: <%= ENV.fetch 'REDIS_URL', 'redis://127.0.0.1:6379/1' %>
+  sidekiq:
+    uri: <%= ENV.fetch 'REDIS_SIDEKIQ_URL', 'redis://127.0.0.1:6379/1' %>
+  cache:
+    uri: <%= ENV.fetch 'REDIS_URL', 'redis://127.0.0.1:6379/1' %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+production:
+  :concurrency: 13
+:queues:
+  - default

--- a/spec/controllers/redis_jobs_controller_spec.rb
+++ b/spec/controllers/redis_jobs_controller_spec.rb
@@ -3,31 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe RedisJobsController, type: :controller do
-  let(:mock_redis_client) { instance_double(Redis) }
-  let(:redis_response) { '{"hold_id":"3911148","result":"success",'\
-                         '"new_value":"Brandywine","new_value_id":"BRANDYWINE"}' }
-
   before do
-    allow(Redis).to receive(:new).and_return(mock_redis_client)
+    $REDIS_CLIENT.set 3911148, "hold_id": '3911148',
+                               "result": 'success',
+                               "new_value": 'Brandywine',
+                               "new_value_id": 'BRANDYWINE'
+  end
+
+  after do
+    $REDIS_CLIENT.del 3911148
   end
 
   describe '#show' do
-    before do
-      allow(mock_redis_client).to receive(:get).and_return(redis_response)
-    end
-
     it 'retrieves and renders json form of the job' do
       get :show, params: { id: 3911148, format: 'json' }
 
-      expect(response.body).to include redis_response
+      expect(response.body).to include 'BRANDYWINE'
     end
   end
 
   describe '#destroy' do
-    before do
-      allow(mock_redis_client).to receive(:del).and_return 1
-    end
-
     it 'sends a delete message to the redis client and returns the results' do
       delete :destroy, params: { id: 3911148 }
 

--- a/spec/controllers/redis_jobs_controller_spec.rb
+++ b/spec/controllers/redis_jobs_controller_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe RedisJobsController, type: :controller do
   before do
-    $REDIS_CLIENT.set 3911148, "hold_id": '3911148',
+    Redis.current.set 3911148, "hold_id": '3911148',
                                "result": 'success',
                                "new_value": 'Brandywine',
                                "new_value_id": 'BRANDYWINE'
   end
 
   after do
-    $REDIS_CLIENT.del 3911148
+    Redis.current.del 3911148
   end
 
   describe '#show' do

--- a/spec/jobs/cancel_hold_job_spec.rb
+++ b/spec/jobs/cancel_hold_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CancelHoldJob, type: :job do
   end
 
   after do
-    $REDIS_CLIENT.flushall
+    Redis.current.flushall
   end
 
   context 'with valid input' do
@@ -27,7 +27,7 @@ RSpec.describe CancelHoldJob, type: :job do
   context 'with valid input that is returned OK from SymphonyClient' do
     it 'sets a Redis value that marks success' do
       described_class.perform_now(**ws_args)
-      results = $REDIS_CLIENT.get 'cancel_hold_1'
+      results = Redis.current.get 'cancel_hold_1'
 
       expect(results).to eq '{"hold_id":1,"result":"success"}'
     end
@@ -46,7 +46,7 @@ RSpec.describe CancelHoldJob, type: :job do
 
     it 'makes a record of the failure' do
       described_class.perform_now(**ws_args)
-      results = $REDIS_CLIENT.get 'cancel_hold_1'
+      results = Redis.current.get 'cancel_hold_1'
 
       expect(results).to eq '{"hold_id":1,"result":"failure","response":"Some error message"}'
     end

--- a/spec/jobs/cancel_hold_job_spec.rb
+++ b/spec/jobs/cancel_hold_job_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe CancelHoldJob, type: :job do
   let(:mock_sc_client) { instance_double(SymphonyClient) }
   let(:ws_args) { { hold_key: 1, session_token: '1s2fa21465' } }
   let(:sc_response) { instance_double(HTTP::Response, status: 200) }
-  let(:redis_client) { instance_double(Redis) }
 
   before do
     allow(SymphonyClient).to receive(:new).and_return(mock_sc_client)
     allow(mock_sc_client).to receive(:cancel_hold).and_return(sc_response)
-    allow(Redis).to receive(:new).and_return(redis_client)
-    allow(redis_client).to receive(:set)
+  end
+
+  after do
+    $REDIS_CLIENT.flushall
   end
 
   context 'with valid input' do
@@ -26,8 +27,9 @@ RSpec.describe CancelHoldJob, type: :job do
   context 'with valid input that is returned OK from SymphonyClient' do
     it 'sets a Redis value that marks success' do
       described_class.perform_now(**ws_args)
+      results = $REDIS_CLIENT.get 'cancel_hold_1'
 
-      expect(redis_client).to have_received(:set).with('cancel_hold_1', /success/)
+      expect(results).to eq '{"hold_id":1,"result":"success"}'
     end
   end
 
@@ -44,9 +46,9 @@ RSpec.describe CancelHoldJob, type: :job do
 
     it 'makes a record of the failure' do
       described_class.perform_now(**ws_args)
+      results = $REDIS_CLIENT.get 'cancel_hold_1'
 
-      expect(redis_client).to have_received(:set).with('cancel_hold_1', '{"hold_id":1,"result":'\
-                                                                    '"failure","response":"Some error message"}')
+      expect(results).to eq '{"hold_id":1,"result":"failure","response":"Some error message"}'
     end
   end
 end

--- a/spec/jobs/change_pickup_by_date_job_spec.rb
+++ b/spec/jobs/change_pickup_by_date_job_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe ChangePickupByDateJob, type: :job do
                       pickup_by_date: '2010-01-01',
                       session_token: '1s2fa21465' } }
     let(:sc_response) { instance_double(HTTP::Response, status: 200) }
-    let(:redis_client) { instance_double(Redis) }
 
     before do
       allow(SymphonyClient).to receive(:new).and_return(mock_sc_client)
       allow(mock_sc_client).to receive(:not_needed_after).and_return(sc_response)
-      allow(Redis).to receive(:new).and_return(redis_client)
-      allow(redis_client).to receive(:set)
+    end
+
+    after do
+      $REDIS_CLIENT.flushall
     end
 
     context 'with valid input' do
@@ -29,14 +30,16 @@ RSpec.describe ChangePickupByDateJob, type: :job do
     context 'with valid input that is returned OK from SymphonyClient' do
       it 'sets a Redis value that marks success' do
         described_class.perform_now(**ws_args)
+        results = $REDIS_CLIENT.get 'pickup_by_date_1'
 
-        expect(redis_client).to have_received(:set).with('pickup_by_date_1', /success/)
+        expect(results).to be_present
       end
 
-      it 'sets a Redis value that contains a translated pickup library code' do
+      it 'sets a Redis value that contains a human-friendly formatted date string' do
         described_class.perform_now(**ws_args)
+        results = $REDIS_CLIENT.get 'pickup_by_date_1'
 
-        expect(redis_client).to have_received(:set).with('pickup_by_date_1', /2010-01-01/)
+        expect(results).to include 'January 1, 2010'
       end
     end
 
@@ -53,9 +56,9 @@ RSpec.describe ChangePickupByDateJob, type: :job do
 
       it 'makes a record of the failure' do
         described_class.perform_now(**ws_args)
+        results = $REDIS_CLIENT.get 'pickup_by_date_1'
 
-        expect(redis_client).to have_received(:set).with('pickup_by_date_1', '{"hold_id":1,"result":'\
-                                                                    '"failure","response":"Some error message"}')
+        expect(results).to eq '{"hold_id":1,"result":"failure","response":"Some error message"}'
       end
     end
   end

--- a/spec/jobs/change_pickup_by_date_job_spec.rb
+++ b/spec/jobs/change_pickup_by_date_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChangePickupByDateJob, type: :job do
     end
 
     after do
-      $REDIS_CLIENT.flushall
+      Redis.current.flushall
     end
 
     context 'with valid input' do
@@ -30,14 +30,14 @@ RSpec.describe ChangePickupByDateJob, type: :job do
     context 'with valid input that is returned OK from SymphonyClient' do
       it 'sets a Redis value that marks success' do
         described_class.perform_now(**ws_args)
-        results = $REDIS_CLIENT.get 'pickup_by_date_1'
+        results = Redis.current.get 'pickup_by_date_1'
 
         expect(results).to be_present
       end
 
       it 'sets a Redis value that contains a human-friendly formatted date string' do
         described_class.perform_now(**ws_args)
-        results = $REDIS_CLIENT.get 'pickup_by_date_1'
+        results = Redis.current.get 'pickup_by_date_1'
 
         expect(results).to include 'January 1, 2010'
       end
@@ -56,7 +56,7 @@ RSpec.describe ChangePickupByDateJob, type: :job do
 
       it 'makes a record of the failure' do
         described_class.perform_now(**ws_args)
-        results = $REDIS_CLIENT.get 'pickup_by_date_1'
+        results = Redis.current.get 'pickup_by_date_1'
 
         expect(results).to eq '{"hold_id":1,"result":"failure","response":"Some error message"}'
       end

--- a/spec/jobs/change_pickup_library_job_spec.rb
+++ b/spec/jobs/change_pickup_library_job_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe ChangePickupLibraryJob, type: :job do
                       pickup_library: 'HERSHEY',
                       session_token: '1s2fa21465' } }
     let(:sc_response) { instance_double(HTTP::Response, status: 200) }
-    let(:redis_client) { instance_double(Redis) }
 
     before do
       allow(SymphonyClient).to receive(:new).and_return(mock_sc_client)
       allow(mock_sc_client).to receive(:change_pickup_library).and_return(sc_response)
-      allow(Redis).to receive(:new).and_return(redis_client)
-      allow(redis_client).to receive(:set)
+    end
+
+    after do
+      $REDIS_CLIENT.flushall
     end
 
     context 'with valid input' do
@@ -29,14 +30,16 @@ RSpec.describe ChangePickupLibraryJob, type: :job do
     context 'with valid input that is returned OK from SymphonyClient' do
       it 'sets a Redis value that marks success' do
         described_class.perform_now(**ws_args)
+        results = $REDIS_CLIENT.get 'pickup_library_1'
 
-        expect(redis_client).to have_received(:set).with('pickup_library_1', /success/)
+        expect(results).to be_present
       end
 
       it 'sets a Redis value that contains a translated pickup library code' do
         described_class.perform_now(**ws_args)
+        results = $REDIS_CLIENT.get 'pickup_library_1'
 
-        expect(redis_client).to have_received(:set).with('pickup_library_1', /Hershey \(College of Medicine\)/)
+        expect(results).to include 'Hershey (College of Medicine)'
       end
     end
 
@@ -53,9 +56,9 @@ RSpec.describe ChangePickupLibraryJob, type: :job do
 
       it 'makes a record of the failure' do
         described_class.perform_now(**ws_args)
+        results = $REDIS_CLIENT.get 'pickup_library_1'
 
-        expect(redis_client).to have_received(:set).with('pickup_library_1', '{"hold_id":1,"result":'\
-                                                                    '"failure","response":"Some error message"}')
+        expect(results).to eq '{"hold_id":1,"result":"failure","response":"Some error message"}'
       end
     end
   end

--- a/spec/jobs/change_pickup_library_job_spec.rb
+++ b/spec/jobs/change_pickup_library_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChangePickupLibraryJob, type: :job do
     end
 
     after do
-      $REDIS_CLIENT.flushall
+      Redis.current.flushall
     end
 
     context 'with valid input' do
@@ -30,14 +30,14 @@ RSpec.describe ChangePickupLibraryJob, type: :job do
     context 'with valid input that is returned OK from SymphonyClient' do
       it 'sets a Redis value that marks success' do
         described_class.perform_now(**ws_args)
-        results = $REDIS_CLIENT.get 'pickup_library_1'
+        results = Redis.current.get 'pickup_library_1'
 
         expect(results).to be_present
       end
 
       it 'sets a Redis value that contains a translated pickup library code' do
         described_class.perform_now(**ws_args)
-        results = $REDIS_CLIENT.get 'pickup_library_1'
+        results = Redis.current.get 'pickup_library_1'
 
         expect(results).to include 'Hershey (College of Medicine)'
       end
@@ -56,7 +56,7 @@ RSpec.describe ChangePickupLibraryJob, type: :job do
 
       it 'makes a record of the failure' do
         described_class.perform_now(**ws_args)
-        results = $REDIS_CLIENT.get 'pickup_library_1'
+        results = Redis.current.get 'pickup_library_1'
 
         expect(results).to eq '{"hold_id":1,"result":"failure","response":"Some error message"}'
       end

--- a/spec/jobs/view_holds_job_spec.rb
+++ b/spec/jobs/view_holds_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ViewHoldsJob, type: :job do
                     session_token: '1s2fa21465' } }
 
   after do
-    $REDIS_CLIENT.flushall
+    Redis.current.flushall
   end
 
   context 'with valid input' do
@@ -17,14 +17,14 @@ RSpec.describe ViewHoldsJob, type: :job do
 
     it 'sets a Redis record containing success denoted by patron\'s key' do
       described_class.perform_now(**ws_args)
-      results = $REDIS_CLIENT.get 'view_holds_patron1'
+      results = Redis.current.get 'view_holds_patron1'
 
       expect(results).to be_present
     end
 
     it 'renders HTML containing the holds and saves to redis' do
       described_class.perform_now(**ws_args)
-      results = $REDIS_CLIENT.get 'view_holds_patron1'
+      results = Redis.current.get 'view_holds_patron1'
 
       expect(results).to include 'Campfires of freedom : the camp life of Black soldiers during the Civil War'
     end
@@ -38,7 +38,7 @@ RSpec.describe ViewHoldsJob, type: :job do
 
     it 'sets a Redis record containing failure denoted by patron\'s key' do
       described_class.perform_now(**ws_args)
-      results = $REDIS_CLIENT.get 'view_holds_patron1'
+      results = Redis.current.get 'view_holds_patron1'
 
       expect(results).to eq '{"result":"failure","response":{"messageList":[{"message":"A bad thing happened"}]}}'
     end


### PR DESCRIPTION
These changes allow for Heroku to work with Redis for everything we use Redis for: caching, Sidkiq and temporary "database"

Key change was making the "database" connection defined once as a global constant.