### PR TITLE
Adds feature spec for new hold form population

### DIFF
--- a/spec/features/holds_spec.rb
+++ b/spec/features/holds_spec.rb
@@ -49,4 +49,11 @@ RSpec.describe 'Holds', type: :feature do
       expect(page).to have_css '#hold3906718 .hold_status', text: 'Cancelled'
     end
   end
+
+  context 'when a patron attempts to create a hold for a monograph', js: true do
+    it 'renders a form for the item being requested' do
+      visit '/holds/new?catkey=6066288'
+      expect(page).to have_text 'Title: 13 bankers : the Wall Street takeover and the next financial meltdown'
+    end
+  end
 end

--- a/spec/support/data/other/bib_6066288.json
+++ b/spec/support/data/other/bib_6066288.json
@@ -1,0 +1,1268 @@
+{
+  "resource": "/catalog/bib",
+  "key": "6066288",
+  "fields": {
+    "shadowed": false,
+    "author": "Johnson, Simon, 1963-",
+    "titleControlNumber": "l2010000168",
+    "catalogDate": "2010-05-25",
+    "catalogFormat": {
+      "resource": "/policy/catalogFormat",
+      "key": "MARC"
+    },
+    "modifiedDate": "2016-10-03",
+    "bib": {
+      "standard": "MARC21",
+      "type": "BIB",
+      "leader": "     cam a22      a 4500",
+      "fields": [
+        {
+          "tag": "001",
+          "subfields": [
+            {
+              "code": "_",
+              "data": "a6066288"
+            }
+          ]
+        },
+        {
+          "tag": "003",
+          "subfields": [
+            {
+              "code": "_",
+              "data": "SIRSI"
+            }
+          ]
+        },
+        {
+          "tag": "005",
+          "subfields": [
+            {
+              "code": "_",
+              "data": "20151215161606.0"
+            }
+          ]
+        },
+        {
+          "tag": "008",
+          "subfields": [
+            {
+              "code": "_",
+              "data": "100121t20102010nyua     b    001 0 eng"
+            }
+          ]
+        },
+        {
+          "tag": "010",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "  2010000168"
+            }
+          ]
+        },
+        {
+          "tag": "019",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "MARS"
+            }
+          ]
+        },
+        {
+          "tag": "020",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "9780307379054 :"
+            },
+            {
+              "code": "c",
+              "data": "$26.95"
+            }
+          ]
+        },
+        {
+          "tag": "020",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "0307379051"
+            }
+          ]
+        },
+        {
+          "tag": "035",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "WB3160801"
+            }
+          ]
+        },
+        {
+          "tag": "035",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "(OCoLC)429021924"
+            }
+          ]
+        },
+        {
+          "tag": "040",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "DLC"
+            },
+            {
+              "code": "c",
+              "data": "DLC"
+            },
+            {
+              "code": "d",
+              "data": "YDX"
+            },
+            {
+              "code": "d",
+              "data": "MOF"
+            },
+            {
+              "code": "d",
+              "data": "IK2"
+            },
+            {
+              "code": "d",
+              "data": "YDXCP"
+            },
+            {
+              "code": "d",
+              "data": "GO3"
+            },
+            {
+              "code": "d",
+              "data": "UPZ"
+            },
+            {
+              "code": "d",
+              "data": "BWX"
+            },
+            {
+              "code": "d",
+              "data": "ABG"
+            },
+            {
+              "code": "d",
+              "data": "CDX"
+            },
+            {
+              "code": "d",
+              "data": "LMR"
+            },
+            {
+              "code": "d",
+              "data": "VP@"
+            },
+            {
+              "code": "d",
+              "data": "UtOrBLW"
+            }
+          ]
+        },
+        {
+          "tag": "043",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "n-us---"
+            }
+          ]
+        },
+        {
+          "tag": "049",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "UPMM"
+            }
+          ]
+        },
+        {
+          "tag": "050",
+          "inds": "00",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "HG2491"
+            },
+            {
+              "code": "b",
+              "data": ".J646 2010"
+            }
+          ]
+        },
+        {
+          "tag": "082",
+          "inds": "00",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "332.10973"
+            },
+            {
+              "code": "2",
+              "data": "22"
+            }
+          ]
+        },
+        {
+          "tag": "100",
+          "inds": "1 ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Johnson, Simon,"
+            },
+            {
+              "code": "d",
+              "data": "1963-"
+            }
+          ]
+        },
+        {
+          "tag": "245",
+          "inds": "10",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "13 bankers :"
+            },
+            {
+              "code": "b",
+              "data": "the Wall Street takeover and the next financial meltdown /"
+            },
+            {
+              "code": "c",
+              "data": "Simon Johnson and James Kwak."
+            }
+          ]
+        },
+        {
+          "tag": "246",
+          "inds": "3 ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Thirteen bankers"
+            }
+          ]
+        },
+        {
+          "tag": "250",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "1st ed."
+            }
+          ]
+        },
+        {
+          "tag": "264",
+          "inds": " 1",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "New York :"
+            },
+            {
+              "code": "b",
+              "data": "Pantheon Books,"
+            },
+            {
+              "code": "c",
+              "data": "[2010]"
+            }
+          ]
+        },
+        {
+          "tag": "264",
+          "inds": " 4",
+          "subfields": [
+            {
+              "code": "c",
+              "data": "©2010"
+            }
+          ]
+        },
+        {
+          "tag": "300",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "304 pages :"
+            },
+            {
+              "code": "b",
+              "data": "illustrations ;"
+            },
+            {
+              "code": "c",
+              "data": "25 cm"
+            }
+          ]
+        },
+        {
+          "tag": "336",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "text"
+            },
+            {
+              "code": "b",
+              "data": "txt"
+            },
+            {
+              "code": "2",
+              "data": "rdacontent"
+            }
+          ]
+        },
+        {
+          "tag": "337",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "unmediated"
+            },
+            {
+              "code": "b",
+              "data": "n"
+            },
+            {
+              "code": "2",
+              "data": "rdamedia"
+            }
+          ]
+        },
+        {
+          "tag": "338",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "volume"
+            },
+            {
+              "code": "b",
+              "data": "nc"
+            },
+            {
+              "code": "2",
+              "data": "rdacarrier"
+            }
+          ]
+        },
+        {
+          "tag": "504",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Includes bibliographical references (pages [223]-278) and index."
+            }
+          ]
+        },
+        {
+          "tag": "505",
+          "inds": "0 ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "13 bankers -- Thomas Jefferson and the financial aristocracy -- Other people's oligarchs -- Wall Street rising : 1980-- -- \"Greed is good\" : the takeover -- The best deal ever -- Too big to fail -- The American oligarchy : six banks."
+            }
+          ]
+        },
+        {
+          "tag": "520",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Johnson and Kwak examine not only how Wall Street's ideology, wealth, and political power among policy makers in Washington led to the financial debacle of 2008, but also what the lessons learned portend for the future."
+            }
+          ]
+        },
+        {
+          "tag": "541",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "3",
+              "data": "Abington copy:"
+            },
+            {
+              "code": "c",
+              "data": "Purchased with funds from the"
+            },
+            {
+              "code": "a",
+              "data": "Paterno Libraries Endowment;"
+            },
+            {
+              "code": "d",
+              "data": "2009."
+            },
+            {
+              "code": "5",
+              "data": "PSt."
+            }
+          ]
+        },
+        {
+          "tag": "541",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "3",
+              "data": "Brandywine copy:"
+            },
+            {
+              "code": "c",
+              "data": "Purchased with funds from the"
+            },
+            {
+              "code": "a",
+              "data": "Paterno Libraries Endowment;"
+            },
+            {
+              "code": "d",
+              "data": "2009."
+            },
+            {
+              "code": "5",
+              "data": "PSt."
+            }
+          ]
+        },
+        {
+          "tag": "541",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "3",
+              "data": "Wilkes-Barre copy:"
+            },
+            {
+              "code": "c",
+              "data": "Purchased with funds from the"
+            },
+            {
+              "code": "a",
+              "data": "Paterno Libraries Endowment;"
+            },
+            {
+              "code": "d",
+              "data": "2009."
+            },
+            {
+              "code": "5",
+              "data": "PSt."
+            }
+          ]
+        },
+        {
+          "tag": "596",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "ABINGTON BERKS BRANDYWINE HARRISBURG WILKESBAR UP-PAT ZREMOVED"
+            }
+          ]
+        },
+        {
+          "tag": "650",
+          "inds": " 0",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Banks and banking"
+            },
+            {
+              "code": "z",
+              "data": "United States."
+            }
+          ]
+        },
+        {
+          "tag": "650",
+          "inds": " 0",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Bank failures"
+            },
+            {
+              "code": "z",
+              "data": "United States."
+            }
+          ]
+        },
+        {
+          "tag": "650",
+          "inds": " 0",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Finance"
+            },
+            {
+              "code": "z",
+              "data": "United States."
+            }
+          ]
+        },
+        {
+          "tag": "650",
+          "inds": " 0",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Financial crises"
+            },
+            {
+              "code": "z",
+              "data": "United States."
+            }
+          ]
+        },
+        {
+          "tag": "700",
+          "inds": "1 ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "Kwak, James."
+            }
+          ]
+        },
+        {
+          "tag": "949",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "HG2491.J646 2010"
+            },
+            {
+              "code": "h",
+              "data": "WBSTBK"
+            },
+            {
+              "code": "i",
+              "data": "000067805754"
+            },
+            {
+              "code": "k",
+              "data": "STACKS-WB"
+            },
+            {
+              "code": "l",
+              "data": "STACKS-WB"
+            },
+            {
+              "code": "m",
+              "data": "WILKESBAR"
+            },
+            {
+              "code": "r",
+              "data": "C"
+            },
+            {
+              "code": "s",
+              "data": "Yes"
+            },
+            {
+              "code": "t",
+              "data": "BOOK"
+            },
+            {
+              "code": "w",
+              "data": "LC"
+            }
+          ]
+        },
+        {
+          "tag": "949",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "HG2491.J646 2010"
+            },
+            {
+              "code": "h",
+              "data": "HBLEBK"
+            },
+            {
+              "code": "i",
+              "data": "000067784004"
+            },
+            {
+              "code": "k",
+              "data": "LEISURE-HB"
+            },
+            {
+              "code": "l",
+              "data": "LEISURE-HB"
+            },
+            {
+              "code": "m",
+              "data": "HARRISBURG"
+            },
+            {
+              "code": "r",
+              "data": "NC"
+            },
+            {
+              "code": "s",
+              "data": "Yes"
+            },
+            {
+              "code": "t",
+              "data": "BOOK"
+            },
+            {
+              "code": "w",
+              "data": "LC"
+            }
+          ]
+        },
+        {
+          "tag": "949",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "HG2491.J646 2010"
+            },
+            {
+              "code": "h",
+              "data": "DESTBK"
+            },
+            {
+              "code": "i",
+              "data": "000067897247"
+            },
+            {
+              "code": "k",
+              "data": "STACKS-DE"
+            },
+            {
+              "code": "l",
+              "data": "STACKS-DE"
+            },
+            {
+              "code": "m",
+              "data": "BRANDYWINE"
+            },
+            {
+              "code": "r",
+              "data": "C"
+            },
+            {
+              "code": "s",
+              "data": "Yes"
+            },
+            {
+              "code": "t",
+              "data": "BOOK"
+            },
+            {
+              "code": "w",
+              "data": "LC"
+            }
+          ]
+        },
+        {
+          "tag": "949",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "HG2491.J646 2010"
+            },
+            {
+              "code": "h",
+              "data": "ABSTBK"
+            },
+            {
+              "code": "i",
+              "data": "000064209296"
+            },
+            {
+              "code": "k",
+              "data": "STACKS-AB"
+            },
+            {
+              "code": "l",
+              "data": "STACKS-AB"
+            },
+            {
+              "code": "m",
+              "data": "ABINGTON"
+            },
+            {
+              "code": "r",
+              "data": "C"
+            },
+            {
+              "code": "s",
+              "data": "Yes"
+            },
+            {
+              "code": "t",
+              "data": "BOOK"
+            },
+            {
+              "code": "w",
+              "data": "LC"
+            }
+          ]
+        },
+        {
+          "tag": "980",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "2010-05-20"
+            },
+            {
+              "code": "e",
+              "data": "22.10"
+            },
+            {
+              "code": "f",
+              "data": "991489"
+            },
+            {
+              "code": "j",
+              "data": "CLOTH"
+            },
+            {
+              "code": "n",
+              "data": "YBPWB"
+            },
+            {
+              "code": "x",
+              "data": "138.35"
+            }
+          ]
+        },
+        {
+          "tag": "980",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "2010-05-13"
+            },
+            {
+              "code": "e",
+              "data": "22.10"
+            },
+            {
+              "code": "f",
+              "data": "985067"
+            },
+            {
+              "code": "j",
+              "data": "CLOTH"
+            },
+            {
+              "code": "n",
+              "data": "YBPHA"
+            },
+            {
+              "code": "x",
+              "data": "845.31"
+            }
+          ]
+        },
+        {
+          "tag": "980",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "2010-05-06"
+            },
+            {
+              "code": "e",
+              "data": "22.10"
+            },
+            {
+              "code": "f",
+              "data": "979343"
+            },
+            {
+              "code": "j",
+              "data": "CLOTH"
+            },
+            {
+              "code": "n",
+              "data": "YBPDE"
+            },
+            {
+              "code": "x",
+              "data": "808.35"
+            }
+          ]
+        },
+        {
+          "tag": "980",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "2010-04-29"
+            },
+            {
+              "code": "e",
+              "data": "22.10"
+            },
+            {
+              "code": "f",
+              "data": "973237"
+            },
+            {
+              "code": "j",
+              "data": "CLOTH"
+            },
+            {
+              "code": "n",
+              "data": "YBPAB"
+            },
+            {
+              "code": "x",
+              "data": "144.20"
+            }
+          ]
+        },
+        {
+          "tag": "993",
+          "inds": "  ",
+          "subfields": [
+            {
+              "code": "a",
+              "data": "700000010275 "
+            },
+            {
+              "code": "n",
+              "data": "Paterno Libraries Endowment (Campus College Libraries)"
+            }
+          ]
+        }
+      ]
+    },
+    "systemModifiedDate": "2020-07-01T15:35:00-04:00",
+    "title": "13 bankers : the Wall Street takeover and the next financial meltdown",
+    "callList": [
+      {
+        "resource": "/catalog/call",
+        "key": "6066288:1",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "UP-PAT"
+          },
+          "callNumber": "HG2491.J646 2010",
+          "shadowed": false,
+          "volumetric": null,
+          "dispCallNumber": "HG2491.J646 2010",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "6066288"
+          },
+          "itemList": [
+            {
+              "resource": "/catalog/item",
+              "key": "6066288:1:1",
+              "fields": {
+                "call": {
+                  "resource": "/catalog/call",
+                  "key": "6066288:1"
+                },
+                "mediaDesk": null,
+                "itemType": {
+                  "resource": "/policy/itemType",
+                  "key": "BOOK"
+                },
+                "library": {
+                  "resource": "/policy/library",
+                  "key": "UP-PAT"
+                },
+                "shadowed": false,
+                "homeLocation": {
+                  "resource": "/policy/location",
+                  "key": "PATERNO-3"
+                },
+                "copyNumber": 1,
+                "bib": {
+                  "resource": "/catalog/bib",
+                  "key": "6066288"
+                },
+                "barcode": "000068095208",
+                "circulate": false,
+                "currentLocation": {
+                  "resource": "/policy/location",
+                  "key": "CHECKEDOUT"
+                }
+              }
+            }
+          ],
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LC"
+          }
+        }
+      },
+      {
+        "resource": "/catalog/call",
+        "key": "6066288:2",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "ABINGTON"
+          },
+          "callNumber": "HG2491.J646 2010",
+          "shadowed": false,
+          "volumetric": null,
+          "dispCallNumber": "HG2491.J646 2010",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "6066288"
+          },
+          "itemList": [
+            {
+              "resource": "/catalog/item",
+              "key": "6066288:2:1",
+              "fields": {
+                "call": {
+                  "resource": "/catalog/call",
+                  "key": "6066288:2"
+                },
+                "mediaDesk": null,
+                "itemType": {
+                  "resource": "/policy/itemType",
+                  "key": "BOOKFLOAT"
+                },
+                "library": {
+                  "resource": "/policy/library",
+                  "key": "ABINGTON"
+                },
+                "shadowed": false,
+                "homeLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-AB"
+                },
+                "copyNumber": 1,
+                "bib": {
+                  "resource": "/catalog/bib",
+                  "key": "6066288"
+                },
+                "barcode": "000064209296",
+                "circulate": true,
+                "currentLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-AB"
+                }
+              }
+            }
+          ],
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LC"
+          }
+        }
+      },
+      {
+        "resource": "/catalog/call",
+        "key": "6066288:6",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "BERKS"
+          },
+          "callNumber": "HG2491.J646 2010",
+          "shadowed": false,
+          "volumetric": null,
+          "dispCallNumber": "HG2491.J646 2010",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "6066288"
+          },
+          "itemList": [
+            {
+              "resource": "/catalog/item",
+              "key": "6066288:6:1",
+              "fields": {
+                "call": {
+                  "resource": "/catalog/call",
+                  "key": "6066288:6"
+                },
+                "mediaDesk": null,
+                "itemType": {
+                  "resource": "/policy/itemType",
+                  "key": "BOOKFLOAT"
+                },
+                "library": {
+                  "resource": "/policy/library",
+                  "key": "BERKS"
+                },
+                "shadowed": false,
+                "homeLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-BK"
+                },
+                "copyNumber": 1,
+                "bib": {
+                  "resource": "/catalog/bib",
+                  "key": "6066288"
+                },
+                "barcode": "000061236172",
+                "circulate": true,
+                "currentLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-BK"
+                }
+              }
+            }
+          ],
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LC"
+          }
+        }
+      },
+      {
+        "resource": "/catalog/call",
+        "key": "6066288:3",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "BRANDYWINE"
+          },
+          "callNumber": "HG2491.J646 2010",
+          "shadowed": false,
+          "volumetric": null,
+          "dispCallNumber": "HG2491.J646 2010",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "6066288"
+          },
+          "itemList": [
+            {
+              "resource": "/catalog/item",
+              "key": "6066288:3:1",
+              "fields": {
+                "call": {
+                  "resource": "/catalog/call",
+                  "key": "6066288:3"
+                },
+                "mediaDesk": null,
+                "itemType": {
+                  "resource": "/policy/itemType",
+                  "key": "BOOKFLOAT"
+                },
+                "library": {
+                  "resource": "/policy/library",
+                  "key": "BRANDYWINE"
+                },
+                "shadowed": false,
+                "homeLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-DE"
+                },
+                "copyNumber": 1,
+                "bib": {
+                  "resource": "/catalog/bib",
+                  "key": "6066288"
+                },
+                "barcode": "000067897247",
+                "circulate": true,
+                "currentLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-DE"
+                }
+              }
+            }
+          ],
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LC"
+          }
+        }
+      },
+      {
+        "resource": "/catalog/call",
+        "key": "6066288:4",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "HARRISBURG"
+          },
+          "callNumber": "HG2491.J646 2010",
+          "shadowed": false,
+          "volumetric": null,
+          "dispCallNumber": "HG2491.J646 2010",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "6066288"
+          },
+          "itemList": [
+            {
+              "resource": "/catalog/item",
+              "key": "6066288:4:1",
+              "fields": {
+                "call": {
+                  "resource": "/catalog/call",
+                  "key": "6066288:4"
+                },
+                "mediaDesk": null,
+                "itemType": {
+                  "resource": "/policy/itemType",
+                  "key": "BOOKFLOAT"
+                },
+                "library": {
+                  "resource": "/policy/library",
+                  "key": "HARRISBURG"
+                },
+                "shadowed": false,
+                "homeLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-HB3"
+                },
+                "copyNumber": 1,
+                "bib": {
+                  "resource": "/catalog/bib",
+                  "key": "6066288"
+                },
+                "barcode": "000067784004",
+                "circulate": true,
+                "currentLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-HB3"
+                }
+              }
+            }
+          ],
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LC"
+          }
+        }
+      },
+      {
+        "resource": "/catalog/call",
+        "key": "6066288:5",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "WILKESBAR"
+          },
+          "callNumber": "HG2491.J646 2010",
+          "shadowed": false,
+          "volumetric": null,
+          "dispCallNumber": "HG2491.J646 2010",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "6066288"
+          },
+          "itemList": [
+            {
+              "resource": "/catalog/item",
+              "key": "6066288:5:1",
+              "fields": {
+                "call": {
+                  "resource": "/catalog/call",
+                  "key": "6066288:5"
+                },
+                "mediaDesk": null,
+                "itemType": {
+                  "resource": "/policy/itemType",
+                  "key": "BOOKFLOAT"
+                },
+                "library": {
+                  "resource": "/policy/library",
+                  "key": "WILKESBAR"
+                },
+                "shadowed": false,
+                "homeLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-WB"
+                },
+                "copyNumber": 1,
+                "bib": {
+                  "resource": "/catalog/bib",
+                  "key": "6066288"
+                },
+                "barcode": "000067805754",
+                "circulate": true,
+                "currentLocation": {
+                  "resource": "/policy/location",
+                  "key": "STACKS-WB"
+                }
+              }
+            }
+          ],
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LC"
+          }
+        }
+      },
+      {
+        "resource": "/catalog/call",
+        "key": "6066288:7",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "ZREMOVED"
+          },
+          "callNumber": "HG2491.J646 2010",
+          "shadowed": false,
+          "volumetric": null,
+          "dispCallNumber": "HG2491.J646 2010",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "6066288"
+          },
+          "itemList": [],
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LC"
+          }
+        }
+      }
+    ],
+    "createDate": "2010-04-02"
+  }
+}

--- a/spec/support/data/other/locations.json
+++ b/spec/support/data/other/locations.json
@@ -1,0 +1,5794 @@
+[
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-MP",
+    "fields": {
+      "displayName": "ARCHIVE-MP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-BU",
+    "fields": {
+      "displayName": "PERIOD-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STORAGE-FE",
+    "fields": {
+      "displayName": "STORAGE-FE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AH-X-TRANS",
+    "fields": {
+      "displayName": "AH-X-TRANS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-BD",
+    "fields": {
+      "displayName": "REF-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-AA",
+    "fields": {
+      "displayName": "MICROS-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GRFCNOV-FE",
+    "fields": {
+      "displayName": "GRFCNOV-FE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "UTOPIA",
+    "fields": {
+      "displayName": "UTOPIA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-HY1",
+    "fields": {
+      "displayName": "STACKS-HY1",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-HY2",
+    "fields": {
+      "displayName": "STACKS-HY2",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-HY",
+    "fields": {
+      "displayName": "NEWBOOK-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CATREF-UP",
+    "fields": {
+      "displayName": "CATREF-UP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISURE-YK",
+    "fields": {
+      "displayName": "LEISURE-YK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-IN",
+    "fields": {
+      "displayName": "FOLIO-IN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-BD",
+    "fields": {
+      "displayName": "PERIOD-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATERNO-1",
+    "fields": {
+      "displayName": "PATERNO-1",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CHECKEDOUT",
+    "fields": {
+      "displayName": "CHECKEDOUT",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOC-MICROS",
+    "fields": {
+      "displayName": "DOC-MICROS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AMER-GIFT",
+    "fields": {
+      "displayName": "AMER-GIFT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATERNO-3",
+    "fields": {
+      "displayName": "PATERNO-3",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATERNO-2",
+    "fields": {
+      "displayName": "PATERNO-2",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-YK",
+    "fields": {
+      "displayName": "STACKS-YK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATERNO-5",
+    "fields": {
+      "displayName": "PATERNO-5",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SLAVIC",
+    "fields": {
+      "displayName": "SLAVIC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPEC-REF",
+    "fields": {
+      "displayName": "SPEC-REF",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATERNO-4",
+    "fields": {
+      "displayName": "PATERNO-4",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MASONIC",
+    "fields": {
+      "displayName": "MASONIC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-AH",
+    "fields": {
+      "displayName": "REF-AH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "IN-MARKING",
+    "fields": {
+      "displayName": "IN-MARKING",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-AA",
+    "fields": {
+      "displayName": "RESERVE-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAPS-MP",
+    "fields": {
+      "displayName": "MAPS-MP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-SERIALS",
+    "fields": {
+      "displayName": "HC-SERIALS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-AC",
+    "fields": {
+      "displayName": "RESERVE-AC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-AB",
+    "fields": {
+      "displayName": "RESERVE-AB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AVAIL_SOON",
+    "fields": {
+      "displayName": "AVAIL_SOON",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FACULTY-BD",
+    "fields": {
+      "displayName": "FACULTY-BD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AUDIO-ARCV",
+    "fields": {
+      "displayName": "AUDIO-ARCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-STORAGE",
+    "fields": {
+      "displayName": "HC-STORAGE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSINGBD",
+    "fields": {
+      "displayName": "BROWSINGBD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CLINIC-DN",
+    "fields": {
+      "displayName": "CLINIC-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-AH",
+    "fields": {
+      "displayName": "RESERVE-AH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-COLD",
+    "fields": {
+      "displayName": "SPC-COLD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESDESK-DN",
+    "fields": {
+      "displayName": "RESDESK-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CIRCDESKHN",
+    "fields": {
+      "displayName": "CIRCDESKHN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ON-ORDER",
+    "fields": {
+      "displayName": "ON-ORDER",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOST-ASSUM",
+    "fields": {
+      "displayName": "LOST-ASSUM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NONPRTR-GV",
+    "fields": {
+      "displayName": "NONPRTR-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-BR",
+    "fields": {
+      "displayName": "REF-BR",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-MA",
+    "fields": {
+      "displayName": "ARCHIVE-MA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ASKDESK-AC",
+    "fields": {
+      "displayName": "ASKDESK-AC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CLINIC-DP",
+    "fields": {
+      "displayName": "CLINIC-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-BU",
+    "fields": {
+      "displayName": "REF-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-BK",
+    "fields": {
+      "displayName": "REF-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-BLOCK",
+    "fields": {
+      "displayName": "SPC-BLOCK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GRFCNOV-DE",
+    "fields": {
+      "displayName": "GRFCNOV-DE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ENGL-LIT",
+    "fields": {
+      "displayName": "ENGL-LIT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OFFSITE-FE",
+    "fields": {
+      "displayName": "OFFSITE-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-WB",
+    "fields": {
+      "displayName": "ONHOLD-WB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-WD",
+    "fields": {
+      "displayName": "ONHOLD-WD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSINGAA",
+    "fields": {
+      "displayName": "BROWSINGAA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OFFSITE-DN",
+    "fields": {
+      "displayName": "OFFSITE-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSINGAB",
+    "fields": {
+      "displayName": "BROWSINGAB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MCCARTHY",
+    "fields": {
+      "displayName": "MCCARTHY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-LS",
+    "fields": {
+      "displayName": "REFDESK-LS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROIN-DN",
+    "fields": {
+      "displayName": "MICROIN-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "KNEEBONE",
+    "fields": {
+      "displayName": "KNEEBONE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SWARTZ",
+    "fields": {
+      "displayName": "SWARTZ",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROIN-DP",
+    "fields": {
+      "displayName": "MICROIN-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-LS",
+    "fields": {
+      "displayName": "INDEXES-LS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REPAIR",
+    "fields": {
+      "displayName": "REPAIR",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESHELVING",
+    "fields": {
+      "displayName": "RESHELVING",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESDESK-DP",
+    "fields": {
+      "displayName": "RESDESK-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWDVD-FE",
+    "fields": {
+      "displayName": "NEWDVD-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-HENRM",
+    "fields": {
+      "displayName": "SPC-HENRM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CIRCDESKHY",
+    "fields": {
+      "displayName": "CIRCDESKHY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HIGHACRES",
+    "fields": {
+      "displayName": "HIGHACRES",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PROFDEV-EG",
+    "fields": {
+      "displayName": "PROFDEV-EG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-AA",
+    "fields": {
+      "displayName": "REF-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-AB",
+    "fields": {
+      "displayName": "REF-AB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-CATOI",
+    "fields": {
+      "displayName": "SPC-CATOI",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PENNA-DP",
+    "fields": {
+      "displayName": "PENNA-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PENNA-DN",
+    "fields": {
+      "displayName": "PENNA-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-AC",
+    "fields": {
+      "displayName": "REF-AC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-MA2",
+    "fields": {
+      "displayName": "STACKS-MA2",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AUTHORS",
+    "fields": {
+      "displayName": "AUTHORS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DARCHIVE-P",
+    "fields": {
+      "displayName": "DARCHIVE-P",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-AH",
+    "fields": {
+      "displayName": "PERIOD-AH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISURE-WS",
+    "fields": {
+      "displayName": "LEISURE-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-MA1",
+    "fields": {
+      "displayName": "STACKS-MA1",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-AA",
+    "fields": {
+      "displayName": "PERIOD-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PLANTPATEN",
+    "fields": {
+      "displayName": "PLANTPATEN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-WS",
+    "fields": {
+      "displayName": "ONHOLD-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOSTCARD",
+    "fields": {
+      "displayName": "LOSTCARD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILLEND",
+    "fields": {
+      "displayName": "ILLEND",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INSHIPPING",
+    "fields": {
+      "displayName": "INSHIPPING",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-MAPPHO",
+    "fields": {
+      "displayName": "SPC-MAPPHO",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SANBORN-MP",
+    "fields": {
+      "displayName": "SANBORN-MP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-HY",
+    "fields": {
+      "displayName": "DISPLAY-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "POPULAR-EG",
+    "fields": {
+      "displayName": "POPULAR-EG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GOODMAN",
+    "fields": {
+      "displayName": "GOODMAN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OFFSITE-BU",
+    "fields": {
+      "displayName": "OFFSITE-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-ED",
+    "fields": {
+      "displayName": "MICROS-ED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "POPSCI-PM",
+    "fields": {
+      "displayName": "POPSCI-PM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEWB",
+    "fields": {
+      "displayName": "OVERSIZEWB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GROFF",
+    "fields": {
+      "displayName": "GROFF",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-DP",
+    "fields": {
+      "displayName": "NEWBOOK-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NONBIB-REC",
+    "fields": {
+      "displayName": "NONBIB-REC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-DN",
+    "fields": {
+      "displayName": "NEWBOOK-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-DN",
+    "fields": {
+      "displayName": "MICROS-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-NK",
+    "fields": {
+      "displayName": "MEDIA-NK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BNJR-SV",
+    "fields": {
+      "displayName": "BNJR-SV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-DP",
+    "fields": {
+      "displayName": "MICROS-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-PM",
+    "fields": {
+      "displayName": "ONHOLD-PM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-PO",
+    "fields": {
+      "displayName": "ONHOLD-PO",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CLOSERESPA",
+    "fields": {
+      "displayName": "CLOSERESPA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-PA",
+    "fields": {
+      "displayName": "ONHOLD-PA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISABILITY",
+    "fields": {
+      "displayName": "DISABILITY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEWS",
+    "fields": {
+      "displayName": "OVERSIZEWS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GRFCNOV-AB",
+    "fields": {
+      "displayName": "GRFCNOV-AB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-MP",
+    "fields": {
+      "displayName": "REFDESK-MP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AUSTRALIA",
+    "fields": {
+      "displayName": "AUSTRALIA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPECCOL-BK",
+    "fields": {
+      "displayName": "SPECCOL-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPEC-CIRC1",
+    "fields": {
+      "displayName": "SPEC-CIRC1",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PSUARCHIVE",
+    "fields": {
+      "displayName": "PSUARCHIVE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CATO-2",
+    "fields": {
+      "displayName": "CATO-2",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-OHRARM",
+    "fields": {
+      "displayName": "SPC-OHRARM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-1A",
+    "fields": {
+      "displayName": "PATTEE-1A",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ART-ARCHIT",
+    "fields": {
+      "displayName": "ART-ARCHIT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-HY",
+    "fields": {
+      "displayName": "ARCHIVE-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GAINES",
+    "fields": {
+      "displayName": "GAINES",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-MK",
+    "fields": {
+      "displayName": "MEDIA-MK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-LS",
+    "fields": {
+      "displayName": "FOLIO-LS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOST-PAID",
+    "fields": {
+      "displayName": "LOST-PAID",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BNGN-SV",
+    "fields": {
+      "displayName": "BNGN-SV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AS-VAULT",
+    "fields": {
+      "displayName": "AS-VAULT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "THESES-HY",
+    "fields": {
+      "displayName": "THESES-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "KITS-ED",
+    "fields": {
+      "displayName": "KITS-ED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-LV",
+    "fields": {
+      "displayName": "MEDIA-LV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "IDEALAB-BK",
+    "fields": {
+      "displayName": "IDEALAB-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MERIWETHER",
+    "fields": {
+      "displayName": "MERIWETHER",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-BU",
+    "fields": {
+      "displayName": "MICROS-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AX-CATALOG",
+    "fields": {
+      "displayName": "AX-CATALOG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STORAGE-HN",
+    "fields": {
+      "displayName": "STORAGE-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-MK",
+    "fields": {
+      "displayName": "DISPLAY-MK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOCHIST-FE",
+    "fields": {
+      "displayName": "LOCHIST-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RARE-MAPS",
+    "fields": {
+      "displayName": "RARE-MAPS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MCDOWELLSV",
+    "fields": {
+      "displayName": "MCDOWELLSV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MFICHE-NML",
+    "fields": {
+      "displayName": "MFICHE-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-BK",
+    "fields": {
+      "displayName": "NEWBOOK-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-HN",
+    "fields": {
+      "displayName": "INDEXES-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SOFTWAREHN",
+    "fields": {
+      "displayName": "SOFTWAREHN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-HY",
+    "fields": {
+      "displayName": "INDEXES-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RARE-DN",
+    "fields": {
+      "displayName": "RARE-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-BD",
+    "fields": {
+      "displayName": "MICROS-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CCHC-FE",
+    "fields": {
+      "displayName": "CCHC-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEUS",
+    "fields": {
+      "displayName": "OVERSIZEUS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CIRCDESKMA",
+    "fields": {
+      "displayName": "CIRCDESKMA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-EDPAC",
+    "fields": {
+      "displayName": "REF-EDPAC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-ASA",
+    "fields": {
+      "displayName": "HC-ASA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INSTRUC-ED",
+    "fields": {
+      "displayName": "INSTRUC-ED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OHARA-SL",
+    "fields": {
+      "displayName": "OHARA-SL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PSUARC-GCS",
+    "fields": {
+      "displayName": "PSUARC-GCS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GRFCNOV-BR",
+    "fields": {
+      "displayName": "GRFCNOV-BR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSINGDE",
+    "fields": {
+      "displayName": "BROWSINGDE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-SV",
+    "fields": {
+      "displayName": "ONHOLD-SV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-GENREF",
+    "fields": {
+      "displayName": "HC-GENREF",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "VIDEO-HB",
+    "fields": {
+      "displayName": "VIDEO-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ALLISON-SH",
+    "fields": {
+      "displayName": "ALLISON-SH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-SL",
+    "fields": {
+      "displayName": "ONHOLD-SL",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "TMI",
+    "fields": {
+      "displayName": "TMI",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-AH",
+    "fields": {
+      "displayName": "NEWBOOK-AH",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CATO2-DN",
+    "fields": {
+      "displayName": "CATO2-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CIRCDESKNK",
+    "fields": {
+      "displayName": "CIRCDESKNK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CLOSED-MP",
+    "fields": {
+      "displayName": "CLOSED-MP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-AA",
+    "fields": {
+      "displayName": "NEWBOOK-AA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FACULTY-DP",
+    "fields": {
+      "displayName": "FACULTY-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-AH",
+    "fields": {
+      "displayName": "MICROS-AH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FINEPRINTG",
+    "fields": {
+      "displayName": "FINEPRINTG",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "EMBLEM",
+    "fields": {
+      "displayName": "EMBLEM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEBU",
+    "fields": {
+      "displayName": "OVERSIZEBU",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-LV",
+    "fields": {
+      "displayName": "ONHOLD-LV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HUNTINGTON",
+    "fields": {
+      "displayName": "HUNTINGTON",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FILM-CTR",
+    "fields": {
+      "displayName": "FILM-CTR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PIPEBA714",
+    "fields": {
+      "displayName": "PIPEBA714",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "JUVENILEFE",
+    "fields": {
+      "displayName": "JUVENILEFE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-HN",
+    "fields": {
+      "displayName": "RESERVE-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-BD",
+    "fields": {
+      "displayName": "REFDESK-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "KIENLE-HY",
+    "fields": {
+      "displayName": "KIENLE-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DVD-AH",
+    "fields": {
+      "displayName": "DVD-AH",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-PY",
+    "fields": {
+      "displayName": "STACKS-PY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-SV",
+    "fields": {
+      "displayName": "DISPLAY-SV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-READRM",
+    "fields": {
+      "displayName": "SPC-READRM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "THESIS-NML",
+    "fields": {
+      "displayName": "THESIS-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INVENT-KC",
+    "fields": {
+      "displayName": "INVENT-KC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-BU",
+    "fields": {
+      "displayName": "REFDESK-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-GV",
+    "fields": {
+      "displayName": "RESERVE-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-PRES",
+    "fields": {
+      "displayName": "MEDIA-PRES",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "TEXTBOOKS",
+    "fields": {
+      "displayName": "TEXTBOOKS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "TRANSFER",
+    "fields": {
+      "displayName": "TRANSFER",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-HY",
+    "fields": {
+      "displayName": "MICROS-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-SCIPRK",
+    "fields": {
+      "displayName": "SPC-SCIPRK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RARE-BOOK",
+    "fields": {
+      "displayName": "RARE-BOOK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-HB",
+    "fields": {
+      "displayName": "RESERVE-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFRES-WB",
+    "fields": {
+      "displayName": "REFRES-WB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPECINT-HB",
+    "fields": {
+      "displayName": "SPECINT-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-2",
+    "fields": {
+      "displayName": "PATTEE-2",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-RAILRD",
+    "fields": {
+      "displayName": "HC-RAILRD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-3",
+    "fields": {
+      "displayName": "PATTEE-3",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-HN",
+    "fields": {
+      "displayName": "MICROS-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-PM",
+    "fields": {
+      "displayName": "NEWBOOK-PM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-1",
+    "fields": {
+      "displayName": "PATTEE-1",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HIST-ED",
+    "fields": {
+      "displayName": "HIST-ED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PENN-EM",
+    "fields": {
+      "displayName": "PENN-EM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PACTBKE-UP",
+    "fields": {
+      "displayName": "PACTBKE-UP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-HB",
+    "fields": {
+      "displayName": "MICROS-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BUS-MEDIA",
+    "fields": {
+      "displayName": "BUS-MEDIA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOST-CLAIM",
+    "fields": {
+      "displayName": "LOST-CLAIM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-W3",
+    "fields": {
+      "displayName": "PATTEE-W3",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-AB",
+    "fields": {
+      "displayName": "REFDESK-AB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-W1",
+    "fields": {
+      "displayName": "PATTEE-W1",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-W2",
+    "fields": {
+      "displayName": "PATTEE-W2",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RARE-RACE",
+    "fields": {
+      "displayName": "RARE-RACE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RAMP-DP",
+    "fields": {
+      "displayName": "RAMP-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-AH",
+    "fields": {
+      "displayName": "REFDESK-AH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SCANNING",
+    "fields": {
+      "displayName": "SCANNING",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATLASES-WS",
+    "fields": {
+      "displayName": "ATLASES-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BUS-TEXTBK",
+    "fields": {
+      "displayName": "BUS-TEXTBK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-MT",
+    "fields": {
+      "displayName": "ONHOLD-MT",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ACAD-BLDG",
+    "fields": {
+      "displayName": "ACAD-BLDG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-HY",
+    "fields": {
+      "displayName": "RESERVE-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ELECTSERHB",
+    "fields": {
+      "displayName": "ELECTSERHB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "TESTS-AB",
+    "fields": {
+      "displayName": "TESTS-AB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-MK",
+    "fields": {
+      "displayName": "ONHOLD-MK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-HY",
+    "fields": {
+      "displayName": "ILL-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BLOCKS-VLT",
+    "fields": {
+      "displayName": "BLOCKS-VLT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ACQ-ORD",
+    "fields": {
+      "displayName": "ACQ-ORD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEADERSHIP",
+    "fields": {
+      "displayName": "LEADERSHIP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-GV",
+    "fields": {
+      "displayName": "INDEXES-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CLOSERESDP",
+    "fields": {
+      "displayName": "CLOSERESDP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-MA",
+    "fields": {
+      "displayName": "ONHOLD-MA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-PM",
+    "fields": {
+      "displayName": "STACKS-PM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BOOKNOOKSV",
+    "fields": {
+      "displayName": "BOOKNOOKSV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CLOSERESDN",
+    "fields": {
+      "displayName": "CLOSERESDN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OFFSITE-NK",
+    "fields": {
+      "displayName": "OFFSITE-NK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-MD",
+    "fields": {
+      "displayName": "ONHOLD-MD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEBD",
+    "fields": {
+      "displayName": "OVERSIZEBD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-FE",
+    "fields": {
+      "displayName": "RESERVE-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOCS-NK",
+    "fields": {
+      "displayName": "DOCS-NK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-REF",
+    "fields": {
+      "displayName": "SPC-REF",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BKFLOATEMP",
+    "fields": {
+      "displayName": "BKFLOATEMP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-COL",
+    "fields": {
+      "displayName": "PATTEE-COL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PAT-RDG-RM",
+    "fields": {
+      "displayName": "PAT-RDG-RM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-WS",
+    "fields": {
+      "displayName": "ARCHIVE-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "READRM-DP",
+    "fields": {
+      "displayName": "READRM-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-ACAD",
+    "fields": {
+      "displayName": "SPC-ACAD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-YK",
+    "fields": {
+      "displayName": "MEDIA-YK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PACTRBK-UP",
+    "fields": {
+      "displayName": "PACTRBK-UP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-DN",
+    "fields": {
+      "displayName": "INDEXES-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-LV2",
+    "fields": {
+      "displayName": "STACKS-LV2",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DUPLICATE",
+    "fields": {
+      "displayName": "DUPLICATE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-NK",
+    "fields": {
+      "displayName": "ONHOLD-NK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CARPENTER",
+    "fields": {
+      "displayName": "CARPENTER",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-2A",
+    "fields": {
+      "displayName": "PATTEE-2A",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-SL",
+    "fields": {
+      "displayName": "STACKS-SL",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATRIUM-DVD",
+    "fields": {
+      "displayName": "ATRIUM-DVD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESEARCHPA",
+    "fields": {
+      "displayName": "RESEARCHPA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICRO-ARCV",
+    "fields": {
+      "displayName": "MICRO-ARCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-HB",
+    "fields": {
+      "displayName": "ILL-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEAA",
+    "fields": {
+      "displayName": "OVERSIZEAA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MARSHALL",
+    "fields": {
+      "displayName": "MARSHALL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PURPLEQUIL",
+    "fields": {
+      "displayName": "PURPLEQUIL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ACQREF-UP",
+    "fields": {
+      "displayName": "ACQREF-UP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-PATW3",
+    "fields": {
+      "displayName": "SPC-PATW3",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CIRCDESKBD",
+    "fields": {
+      "displayName": "CIRCDESKBD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-EG",
+    "fields": {
+      "displayName": "INDEXES-EG",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "TECHSERVHB",
+    "fields": {
+      "displayName": "TECHSERVHB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAPS-WS",
+    "fields": {
+      "displayName": "MAPS-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SWARTZ-MID",
+    "fields": {
+      "displayName": "SWARTZ-MID",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONLINE",
+    "fields": {
+      "displayName": "ONLINE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-WS",
+    "fields": {
+      "displayName": "MEDIA-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISURE-PA",
+    "fields": {
+      "displayName": "LEISURE-PA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-EM",
+    "fields": {
+      "displayName": "INDEXES-EM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "JUVBIGBOOK",
+    "fields": {
+      "displayName": "JUVBIGBOOK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-YK",
+    "fields": {
+      "displayName": "REF-YK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HENISCH-RM",
+    "fields": {
+      "displayName": "HENISCH-RM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-EG",
+    "fields": {
+      "displayName": "MICROS-EG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-EDHIST",
+    "fields": {
+      "displayName": "REF-EDHIST",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ELECRES-SS",
+    "fields": {
+      "displayName": "ELECRES-SS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CAREER-BK",
+    "fields": {
+      "displayName": "CAREER-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-NML",
+    "fields": {
+      "displayName": "REF-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-DIGARC",
+    "fields": {
+      "displayName": "SPC-DIGARC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-EM",
+    "fields": {
+      "displayName": "MICROS-EM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-VAULT",
+    "fields": {
+      "displayName": "SPC-VAULT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-WB",
+    "fields": {
+      "displayName": "MEDIA-WB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PENNSYLVAN",
+    "fields": {
+      "displayName": "PENNSYLVAN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-DE",
+    "fields": {
+      "displayName": "RESERVE-DE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PUGH",
+    "fields": {
+      "displayName": "PUGH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-GCS",
+    "fields": {
+      "displayName": "HC-GCS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-BD",
+    "fields": {
+      "displayName": "INDEXES-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-DN",
+    "fields": {
+      "displayName": "RESERVE-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOCUSRF-DN",
+    "fields": {
+      "displayName": "DOCUSRF-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-MA",
+    "fields": {
+      "displayName": "MICROS-MA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ANNEX",
+    "fields": {
+      "displayName": "ANNEX",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-DP",
+    "fields": {
+      "displayName": "RESERVE-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-HN",
+    "fields": {
+      "displayName": "ONHOLD-HN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ENCYCL-AH",
+    "fields": {
+      "displayName": "ENCYCL-AH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-PATRNO",
+    "fields": {
+      "displayName": "SPC-PATRNO",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-BK",
+    "fields": {
+      "displayName": "INDEXES-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-HB",
+    "fields": {
+      "displayName": "ONHOLD-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BUS-ALCV",
+    "fields": {
+      "displayName": "BUS-ALCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "VIDEO-AC",
+    "fields": {
+      "displayName": "VIDEO-AC",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DICTION-WS",
+    "fields": {
+      "displayName": "DICTION-WS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MUSICCOLFE",
+    "fields": {
+      "displayName": "MUSICCOLFE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISURE-LV",
+    "fields": {
+      "displayName": "LEISURE-LV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-MAPS",
+    "fields": {
+      "displayName": "HC-MAPS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-US",
+    "fields": {
+      "displayName": "FOLIO-US",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOKNML",
+    "fields": {
+      "displayName": "NEWBOOKNML",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-LS",
+    "fields": {
+      "displayName": "MICROS-LS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RARE-CHILD",
+    "fields": {
+      "displayName": "RARE-CHILD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-EG",
+    "fields": {
+      "displayName": "RESERVE-EG",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-ED",
+    "fields": {
+      "displayName": "REFDESK-ED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-BU",
+    "fields": {
+      "displayName": "INDEXES-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "JUVENILEAA",
+    "fields": {
+      "displayName": "JUVENILEAA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-SV",
+    "fields": {
+      "displayName": "STACKS-SV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-EM",
+    "fields": {
+      "displayName": "RESERVE-EM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISC-DN",
+    "fields": {
+      "displayName": "DISC-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATLASES-SS",
+    "fields": {
+      "displayName": "ATLASES-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GRFCNOV-YK",
+    "fields": {
+      "displayName": "GRFCNOV-YK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NAEA",
+    "fields": {
+      "displayName": "NAEA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-WS",
+    "fields": {
+      "displayName": "REF-WS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "READ",
+    "fields": {
+      "displayName": "READ",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-DS",
+    "fields": {
+      "displayName": "RESERVE-DS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PRESLAB-UP",
+    "fields": {
+      "displayName": "PRESLAB-UP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWS-NML",
+    "fields": {
+      "displayName": "NEWS-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "EDUMEDIAFE",
+    "fields": {
+      "displayName": "EDUMEDIAFE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CAREERS-SS",
+    "fields": {
+      "displayName": "CAREERS-SS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-HY",
+    "fields": {
+      "displayName": "ONHOLD-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INTRANSIT",
+    "fields": {
+      "displayName": "INTRANSIT",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-WB",
+    "fields": {
+      "displayName": "REF-WB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-BD",
+    "fields": {
+      "displayName": "RESERVE-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PEROVER-DN",
+    "fields": {
+      "displayName": "PEROVER-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BINDPRP-DN",
+    "fields": {
+      "displayName": "BINDPRP-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-BK",
+    "fields": {
+      "displayName": "RESERVE-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OHARA",
+    "fields": {
+      "displayName": "OHARA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PEROVER-DP",
+    "fields": {
+      "displayName": "PEROVER-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LANG",
+    "fields": {
+      "displayName": "LANG",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-WB",
+    "fields": {
+      "displayName": "STACKS-WB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCV-ANNEX",
+    "fields": {
+      "displayName": "ARCV-ANNEX",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FILM-PSU",
+    "fields": {
+      "displayName": "FILM-PSU",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LGBTA-ROOM",
+    "fields": {
+      "displayName": "LGBTA-ROOM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LUCAS",
+    "fields": {
+      "displayName": "LUCAS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SWARTZ-YA",
+    "fields": {
+      "displayName": "SWARTZ-YA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-SS",
+    "fields": {
+      "displayName": "FOLIO-SS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-WS",
+    "fields": {
+      "displayName": "STACKS-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-8THAF",
+    "fields": {
+      "displayName": "HC-8THAF",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "VIDEO-ARCV",
+    "fields": {
+      "displayName": "VIDEO-ARCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PIPEBA714A",
+    "fields": {
+      "displayName": "PIPEBA714A",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CCHCREF-FE",
+    "fields": {
+      "displayName": "CCHCREF-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DSLOFFCHRG",
+    "fields": {
+      "displayName": "DSLOFFCHRG",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-AA",
+    "fields": {
+      "displayName": "INDEXES-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPECCOL-YK",
+    "fields": {
+      "displayName": "SPECCOL-YK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HOSTETLER",
+    "fields": {
+      "displayName": "HOSTETLER",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-BK",
+    "fields": {
+      "displayName": "ILL-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ENCYCL-DN",
+    "fields": {
+      "displayName": "ENCYCL-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CATOFF-HY",
+    "fields": {
+      "displayName": "CATOFF-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-BR",
+    "fields": {
+      "displayName": "RESERVE-BR",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ENCYCL-DP",
+    "fields": {
+      "displayName": "ENCYCL-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOST-FIX",
+    "fields": {
+      "displayName": "LOST-FIX",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-AH",
+    "fields": {
+      "displayName": "INDEXES-AH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "EICHE-AA",
+    "fields": {
+      "displayName": "EICHE-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LGPLAN-MP",
+    "fields": {
+      "displayName": "LGPLAN-MP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-GV",
+    "fields": {
+      "displayName": "REFDESK-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LGBTQ-SV",
+    "fields": {
+      "displayName": "LGBTQ-SV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-SL",
+    "fields": {
+      "displayName": "MEDIA-SL",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-BR",
+    "fields": {
+      "displayName": "ILL-BR",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-SV",
+    "fields": {
+      "displayName": "MEDIA-SV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "TECHSERVDN",
+    "fields": {
+      "displayName": "TECHSERVDN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "IDEACOLLBK",
+    "fields": {
+      "displayName": "IDEACOLLBK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "UNKNOWN",
+    "fields": {
+      "displayName": "UNKNOWN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FACULTY-LV",
+    "fields": {
+      "displayName": "FACULTY-LV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HANLEY",
+    "fields": {
+      "displayName": "HANLEY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-DN",
+    "fields": {
+      "displayName": "ONHOLD-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-PO",
+    "fields": {
+      "displayName": "RESERVE-PO",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOCS-HB",
+    "fields": {
+      "displayName": "DOCS-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSINGSL",
+    "fields": {
+      "displayName": "BROWSINGSL",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-DP",
+    "fields": {
+      "displayName": "ONHOLD-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOCUS-DN",
+    "fields": {
+      "displayName": "DOCUS-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-MISS",
+    "fields": {
+      "displayName": "SPC-MISS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-BK",
+    "fields": {
+      "displayName": "MEDIA-BK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-DS",
+    "fields": {
+      "displayName": "ONHOLD-DS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-DE",
+    "fields": {
+      "displayName": "ONHOLD-DE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISURE-HB",
+    "fields": {
+      "displayName": "LEISURE-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "COSTUME",
+    "fields": {
+      "displayName": "COSTUME",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-PY",
+    "fields": {
+      "displayName": "RESERVE-PY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BLACKHIST",
+    "fields": {
+      "displayName": "BLACKHIST",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-HN",
+    "fields": {
+      "displayName": "STACKS-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-RB",
+    "fields": {
+      "displayName": "REF-RB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPECCOL-WS",
+    "fields": {
+      "displayName": "SPECCOL-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-PA",
+    "fields": {
+      "displayName": "RESERVE-PA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDHIST-HY",
+    "fields": {
+      "displayName": "MEDHIST-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISCARD",
+    "fields": {
+      "displayName": "DISCARD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DICTION-SS",
+    "fields": {
+      "displayName": "DICTION-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CIRCDESKWS",
+    "fields": {
+      "displayName": "CIRCDESKWS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAP-ARCV",
+    "fields": {
+      "displayName": "MAP-ARCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDITRM-DN",
+    "fields": {
+      "displayName": "MEDITRM-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-PY",
+    "fields": {
+      "displayName": "MICROS-PY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-PM",
+    "fields": {
+      "displayName": "RESERVE-PM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-BD",
+    "fields": {
+      "displayName": "MEDIA-BD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REJECTED",
+    "fields": {
+      "displayName": "REJECTED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-RH",
+    "fields": {
+      "displayName": "PERIOD-RH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-SS",
+    "fields": {
+      "displayName": "REF-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MFILM-NML",
+    "fields": {
+      "displayName": "MFILM-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-PM",
+    "fields": {
+      "displayName": "MICROS-PM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SWARTZ-PIC",
+    "fields": {
+      "displayName": "SWARTZ-PIC",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-SV",
+    "fields": {
+      "displayName": "REF-SV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEADER-HY",
+    "fields": {
+      "displayName": "LEADER-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-EG",
+    "fields": {
+      "displayName": "ONHOLD-EG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CD-HB",
+    "fields": {
+      "displayName": "CD-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-SL",
+    "fields": {
+      "displayName": "REF-SL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AUDIOBKFE",
+    "fields": {
+      "displayName": "AUDIOBKFE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SERMONS",
+    "fields": {
+      "displayName": "SERMONS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PSUPRESS",
+    "fields": {
+      "displayName": "PSUPRESS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-EM",
+    "fields": {
+      "displayName": "ONHOLD-EM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-SS",
+    "fields": {
+      "displayName": "PERIOD-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CATALOGING",
+    "fields": {
+      "displayName": "CATALOGING",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-GV",
+    "fields": {
+      "displayName": "STACKS-GV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZBDM",
+    "fields": {
+      "displayName": "OVERSIZBDM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "THESIS-GV",
+    "fields": {
+      "displayName": "THESIS-GV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MICROS-PA",
+    "fields": {
+      "displayName": "MICROS-PA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SMALL-MP",
+    "fields": {
+      "displayName": "SMALL-MP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ELECRES-MP",
+    "fields": {
+      "displayName": "ELECRES-MP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-EXHIBT",
+    "fields": {
+      "displayName": "SPC-EXHIBT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CD-HN",
+    "fields": {
+      "displayName": "CD-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-AA",
+    "fields": {
+      "displayName": "MEDIA-AA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-AB",
+    "fields": {
+      "displayName": "MEDIA-AB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AX-CP-LP",
+    "fields": {
+      "displayName": "AX-CP-LP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOC-INTL",
+    "fields": {
+      "displayName": "DOC-INTL",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "THESIS-HB",
+    "fields": {
+      "displayName": "THESIS-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "WITHDRAWN",
+    "fields": {
+      "displayName": "WITHDRAWN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STATUTE-DP",
+    "fields": {
+      "displayName": "STATUTE-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STATUTE-DN",
+    "fields": {
+      "displayName": "STATUTE-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOC-PA",
+    "fields": {
+      "displayName": "DOC-PA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOCUSMF-DN",
+    "fields": {
+      "displayName": "DOCUSMF-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ERESERVES",
+    "fields": {
+      "displayName": "ERESERVES",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AUTHOR-FE",
+    "fields": {
+      "displayName": "AUTHOR-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-PM",
+    "fields": {
+      "displayName": "REF-PM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-PT",
+    "fields": {
+      "displayName": "PERIOD-PT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEHY",
+    "fields": {
+      "displayName": "OVERSIZEHY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-UMW",
+    "fields": {
+      "displayName": "HC-UMW",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DVD-HB",
+    "fields": {
+      "displayName": "DVD-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "JUVENILELV",
+    "fields": {
+      "displayName": "JUVENILELV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEIN",
+    "fields": {
+      "displayName": "OVERSIZEIN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "VIDEO-SS",
+    "fields": {
+      "displayName": "VIDEO-SS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-FE",
+    "fields": {
+      "displayName": "ONHOLD-FE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NONCIRC-EG",
+    "fields": {
+      "displayName": "NONCIRC-EG",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-NK",
+    "fields": {
+      "displayName": "RESERVE-NK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRIC-DE",
+    "fields": {
+      "displayName": "CURRIC-DE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RAREDS-DN",
+    "fields": {
+      "displayName": "RAREDS-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ROBESON",
+    "fields": {
+      "displayName": "ROBESON",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "TESTS-GV",
+    "fields": {
+      "displayName": "TESTS-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SCI-FI",
+    "fields": {
+      "displayName": "SCI-FI",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RAREBKS-HB",
+    "fields": {
+      "displayName": "RAREBKS-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GRFCNOV-WS",
+    "fields": {
+      "displayName": "GRFCNOV-WS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-GV",
+    "fields": {
+      "displayName": "ONHOLD-GV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEHB",
+    "fields": {
+      "displayName": "OVERSIZEHB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-EDPACE",
+    "fields": {
+      "displayName": "REF-EDPACE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SOILSURVEY",
+    "fields": {
+      "displayName": "SOILSURVEY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HJSC-HB",
+    "fields": {
+      "displayName": "HJSC-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AEROSPACE",
+    "fields": {
+      "displayName": "AEROSPACE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATLASES-MA",
+    "fields": {
+      "displayName": "ATLASES-MA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOCUSMD-DN",
+    "fields": {
+      "displayName": "DOCUSMD-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MINISCO",
+    "fields": {
+      "displayName": "MINISCO",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIODARCV",
+    "fields": {
+      "displayName": "PERIODARCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DIGEST-DP",
+    "fields": {
+      "displayName": "DIGEST-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CULTUREHUB",
+    "fields": {
+      "displayName": "CULTUREHUB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DIGEST-DN",
+    "fields": {
+      "displayName": "DIGEST-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATERNO-HR",
+    "fields": {
+      "displayName": "PATERNO-HR",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-LS",
+    "fields": {
+      "displayName": "RESERVE-LS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-ARCHIVE",
+    "fields": {
+      "displayName": "HC-ARCHIVE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-LV",
+    "fields": {
+      "displayName": "RESERVE-LV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-NK",
+    "fields": {
+      "displayName": "REF-NK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-LV",
+    "fields": {
+      "displayName": "STACKS-LV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-SCISTO",
+    "fields": {
+      "displayName": "SPC-SCISTO",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LAPTOP-GWY",
+    "fields": {
+      "displayName": "LAPTOP-GWY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ORDERED",
+    "fields": {
+      "displayName": "ORDERED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-MA",
+    "fields": {
+      "displayName": "STACKS-MA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATHERTON",
+    "fields": {
+      "displayName": "ATHERTON",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LAPTOP-PO",
+    "fields": {
+      "displayName": "LAPTOP-PO",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPECCOL-SL",
+    "fields": {
+      "displayName": "SPECCOL-SL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OPENRES-AC",
+    "fields": {
+      "displayName": "OPENRES-AC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-MD",
+    "fields": {
+      "displayName": "STACKS-MD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISURE-DS",
+    "fields": {
+      "displayName": "LEISURE-DS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWS-HY",
+    "fields": {
+      "displayName": "NEWS-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AUDIO-HB",
+    "fields": {
+      "displayName": "AUDIO-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-BA",
+    "fields": {
+      "displayName": "PATTEE-BA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOCALHIST",
+    "fields": {
+      "displayName": "LOCALHIST",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PALCI",
+    "fields": {
+      "displayName": "PALCI",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-AB",
+    "fields": {
+      "displayName": "ONHOLD-AB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-AC",
+    "fields": {
+      "displayName": "ONHOLD-AC",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-MA",
+    "fields": {
+      "displayName": "RESERVE-MA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SCHWAB",
+    "fields": {
+      "displayName": "SCHWAB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BASEMENTHY",
+    "fields": {
+      "displayName": "BASEMENTHY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISUREDSP",
+    "fields": {
+      "displayName": "LEISUREDSP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-AA",
+    "fields": {
+      "displayName": "ONHOLD-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-MD",
+    "fields": {
+      "displayName": "RESERVE-MD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWBOOK-SS",
+    "fields": {
+      "displayName": "NEWBOOK-SS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ANNEXPREP",
+    "fields": {
+      "displayName": "ANNEXPREP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRISS-HY",
+    "fields": {
+      "displayName": "CURRISS-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-MK",
+    "fields": {
+      "displayName": "RESERVE-MK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-BK",
+    "fields": {
+      "displayName": "ONHOLD-BK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "JUVENILEHB",
+    "fields": {
+      "displayName": "JUVENILEHB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GISROOM-WB",
+    "fields": {
+      "displayName": "GISROOM-WB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-BR",
+    "fields": {
+      "displayName": "ONHOLD-BR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "VAULT",
+    "fields": {
+      "displayName": "VAULT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-BD",
+    "fields": {
+      "displayName": "ONHOLD-BD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NONPRINTGV",
+    "fields": {
+      "displayName": "NONPRINTGV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HC-USWA",
+    "fields": {
+      "displayName": "HC-USWA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-W2F",
+    "fields": {
+      "displayName": "PATTEE-W2F",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-LS",
+    "fields": {
+      "displayName": "PERIOD-LS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BDJNL-PM",
+    "fields": {
+      "displayName": "BDJNL-PM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CATO-PARK",
+    "fields": {
+      "displayName": "CATO-PARK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEISURE-BR",
+    "fields": {
+      "displayName": "LEISURE-BR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY",
+    "fields": {
+      "displayName": "DISPLAY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPCINPROC",
+    "fields": {
+      "displayName": "SPCINPROC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEEM",
+    "fields": {
+      "displayName": "OVERSIZEEM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PIPE1C919",
+    "fields": {
+      "displayName": "PIPE1C919",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEED",
+    "fields": {
+      "displayName": "OVERSIZEED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CD-AH",
+    "fields": {
+      "displayName": "CD-AH",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-MK",
+    "fields": {
+      "displayName": "REF-MK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LEGAL-ALCV",
+    "fields": {
+      "displayName": "LEGAL-ALCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-MK",
+    "fields": {
+      "displayName": "STACKS-MK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AS-GAMES",
+    "fields": {
+      "displayName": "AS-GAMES",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-MP",
+    "fields": {
+      "displayName": "STACKS-MP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRIC-HB",
+    "fields": {
+      "displayName": "CURRIC-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-MP",
+    "fields": {
+      "displayName": "REF-MP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PATTEE-B",
+    "fields": {
+      "displayName": "PATTEE-B",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BLOCKSON",
+    "fields": {
+      "displayName": "BLOCKSON",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CIRC1AA",
+    "fields": {
+      "displayName": "CIRC1AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAP-GUIDES",
+    "fields": {
+      "displayName": "MAP-GUIDES",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CAREERS-LV",
+    "fields": {
+      "displayName": "CAREERS-LV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRIC-GV",
+    "fields": {
+      "displayName": "CURRIC-GV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DVD-BR",
+    "fields": {
+      "displayName": "DVD-BR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-MA",
+    "fields": {
+      "displayName": "REF-MA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "THESIS-HBY",
+    "fields": {
+      "displayName": "THESIS-HBY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-LS",
+    "fields": {
+      "displayName": "REF-LS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-NK",
+    "fields": {
+      "displayName": "STACKS-NK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CAPITAL",
+    "fields": {
+      "displayName": "CAPITAL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-LV",
+    "fields": {
+      "displayName": "REF-LV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEDE",
+    "fields": {
+      "displayName": "OVERSIZEDE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SLTXTBK",
+    "fields": {
+      "displayName": "SLTXTBK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BNYA-SV",
+    "fields": {
+      "displayName": "BNYA-SV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZESL",
+    "fields": {
+      "displayName": "OVERSIZESL",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATLASES-HN",
+    "fields": {
+      "displayName": "ATLASES-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "LOST",
+    "fields": {
+      "displayName": "LOST",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REPORTR-DN",
+    "fields": {
+      "displayName": "REPORTR-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-RESHUB",
+    "fields": {
+      "displayName": "REF-RESHUB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BINDERY-HY",
+    "fields": {
+      "displayName": "BINDERY-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REPORTR-DP",
+    "fields": {
+      "displayName": "REPORTR-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CARREF-BU",
+    "fields": {
+      "displayName": "CARREF-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZESV",
+    "fields": {
+      "displayName": "OVERSIZESV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SCANGOVDOC",
+    "fields": {
+      "displayName": "SCANGOVDOC",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZESS",
+    "fields": {
+      "displayName": "OVERSIZESS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-AC",
+    "fields": {
+      "displayName": "FOLIO-AC",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FEATRFILFE",
+    "fields": {
+      "displayName": "FEATRFILFE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEX-NML",
+    "fields": {
+      "displayName": "INDEX-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAPS-EM",
+    "fields": {
+      "displayName": "MAPS-EM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STORAGE-MP",
+    "fields": {
+      "displayName": "STORAGE-MP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "POPNON-NK",
+    "fields": {
+      "displayName": "POPNON-NK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RARE-GCS",
+    "fields": {
+      "displayName": "RARE-GCS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRICR-GV",
+    "fields": {
+      "displayName": "CURRICR-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-WS",
+    "fields": {
+      "displayName": "INDEXES-WS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AFRIC-AMER",
+    "fields": {
+      "displayName": "AFRIC-AMER",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-BLKVLT",
+    "fields": {
+      "displayName": "SPC-BLKVLT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "COOKBOOKSV",
+    "fields": {
+      "displayName": "COOKBOOKSV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-YK",
+    "fields": {
+      "displayName": "RESERVE-YK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-RH",
+    "fields": {
+      "displayName": "REFDESK-RH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-BK",
+    "fields": {
+      "displayName": "DISPLAY-BK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-YK",
+    "fields": {
+      "displayName": "ILL-YK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STORAGE-MA",
+    "fields": {
+      "displayName": "STORAGE-MA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-SERIAL",
+    "fields": {
+      "displayName": "SPC-SERIAL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HARSHBARGR",
+    "fields": {
+      "displayName": "HARSHBARGR",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-BR",
+    "fields": {
+      "displayName": "DISPLAY-BR",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OPAQUE-NML",
+    "fields": {
+      "displayName": "OPAQUE-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "AMER-LIT",
+    "fields": {
+      "displayName": "AMER-LIT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ROXBURGHE",
+    "fields": {
+      "displayName": "ROXBURGHE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-WS",
+    "fields": {
+      "displayName": "ILL-WS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAPS-HN",
+    "fields": {
+      "displayName": "MAPS-HN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-ARCV",
+    "fields": {
+      "displayName": "REF-ARCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-BD",
+    "fields": {
+      "displayName": "STACKS-BD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "THESIS-BD",
+    "fields": {
+      "displayName": "THESIS-BD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAPS-HB",
+    "fields": {
+      "displayName": "MAPS-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-BK",
+    "fields": {
+      "displayName": "STACKS-BK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-AA",
+    "fields": {
+      "displayName": "DISPLAY-AA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-WB",
+    "fields": {
+      "displayName": "RESERVE-WB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FILM-ARCV",
+    "fields": {
+      "displayName": "FILM-ARCV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-HB",
+    "fields": {
+      "displayName": "REF-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-HY",
+    "fields": {
+      "displayName": "MEDIA-HY",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NEWS-PAT",
+    "fields": {
+      "displayName": "NEWS-PAT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPECCOL-MK",
+    "fields": {
+      "displayName": "SPECCOL-MK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-BR",
+    "fields": {
+      "displayName": "STACKS-BR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-GV",
+    "fields": {
+      "displayName": "REF-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ITALIAN",
+    "fields": {
+      "displayName": "ITALIAN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SMITH",
+    "fields": {
+      "displayName": "SMITH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "VERTFILEBR",
+    "fields": {
+      "displayName": "VERTFILEBR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-HB",
+    "fields": {
+      "displayName": "PERIOD-HB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OFFSITEADN",
+    "fields": {
+      "displayName": "OFFSITEADN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "JUVENIL-ED",
+    "fields": {
+      "displayName": "JUVENIL-ED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-AB",
+    "fields": {
+      "displayName": "STACKS-AB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-AA",
+    "fields": {
+      "displayName": "STACKS-AA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CATO-2MAPS",
+    "fields": {
+      "displayName": "CATO-2MAPS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-SS",
+    "fields": {
+      "displayName": "REFDESK-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-AC",
+    "fields": {
+      "displayName": "STACKS-AC",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARKTHESES",
+    "fields": {
+      "displayName": "ARKTHESES",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ELECRES-BU",
+    "fields": {
+      "displayName": "ELECRES-BU",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PRESREF-UP",
+    "fields": {
+      "displayName": "PRESREF-UP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "NONBOOK-MA",
+    "fields": {
+      "displayName": "NONBOOK-MA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HENISCH",
+    "fields": {
+      "displayName": "HENISCH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MUSIC-CTR",
+    "fields": {
+      "displayName": "MUSIC-CTR",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-WB",
+    "fields": {
+      "displayName": "ILL-WB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSINGHN",
+    "fields": {
+      "displayName": "BROWSINGHN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEPA",
+    "fields": {
+      "displayName": "OVERSIZEPA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "HOLDS",
+    "fields": {
+      "displayName": "HOLDS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PSUARC-MSS",
+    "fields": {
+      "displayName": "PSUARC-MSS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-HY",
+    "fields": {
+      "displayName": "REF-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-HN",
+    "fields": {
+      "displayName": "REF-HN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSE-SS",
+    "fields": {
+      "displayName": "BROWSE-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-WS",
+    "fields": {
+      "displayName": "RESERVE-WS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DEPTCHARGE",
+    "fields": {
+      "displayName": "DEPTCHARGE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PRIESTLEY",
+    "fields": {
+      "displayName": "PRIESTLEY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-DE",
+    "fields": {
+      "displayName": "STACKS-DE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-AB",
+    "fields": {
+      "displayName": "ARCHIVE-AB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-FE",
+    "fields": {
+      "displayName": "REF-FE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-AA",
+    "fields": {
+      "displayName": "ARCHIVE-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RICHTER",
+    "fields": {
+      "displayName": "RICHTER",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL",
+    "fields": {
+      "displayName": "ILL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BINDERY-DN",
+    "fields": {
+      "displayName": "BINDERY-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-DP",
+    "fields": {
+      "displayName": "STACKS-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-DN",
+    "fields": {
+      "displayName": "STACKS-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STAPLETON",
+    "fields": {
+      "displayName": "STAPLETON",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-DS",
+    "fields": {
+      "displayName": "STACKS-DS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOC-CENSUS",
+    "fields": {
+      "displayName": "DOC-CENSUS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRIC-BK",
+    "fields": {
+      "displayName": "CURRIC-BK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-EM",
+    "fields": {
+      "displayName": "REF-EM",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFDESK-WS",
+    "fields": {
+      "displayName": "REFDESK-WS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-ED",
+    "fields": {
+      "displayName": "FOLIO-ED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "COUNTY",
+    "fields": {
+      "displayName": "COUNTY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSE-RH",
+    "fields": {
+      "displayName": "BROWSE-RH",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ENGASCHLBK",
+    "fields": {
+      "displayName": "ENGASCHLBK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-GV",
+    "fields": {
+      "displayName": "PERIOD-GV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DVD-MA",
+    "fields": {
+      "displayName": "DVD-MA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEXES-SS",
+    "fields": {
+      "displayName": "INDEXES-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ETHICS-BK",
+    "fields": {
+      "displayName": "ETHICS-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-NML",
+    "fields": {
+      "displayName": "PERIOD-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MAPS-AA",
+    "fields": {
+      "displayName": "MAPS-AA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "GAMES-BD",
+    "fields": {
+      "displayName": "GAMES-BD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "JUVENIL-BD",
+    "fields": {
+      "displayName": "JUVENIL-BD",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BINDERY",
+    "fields": {
+      "displayName": "BINDERY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CD-ROM-HB",
+    "fields": {
+      "displayName": "CD-ROM-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONHOLD-YK",
+    "fields": {
+      "displayName": "ONHOLD-YK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZENK",
+    "fields": {
+      "displayName": "OVERSIZENK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-UP",
+    "fields": {
+      "displayName": "ILL-UP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-ED",
+    "fields": {
+      "displayName": "MEDIA-ED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REFBMT-HY",
+    "fields": {
+      "displayName": "REFBMT-HY",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRIC-AA",
+    "fields": {
+      "displayName": "CURRIC-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CURRIC-AB",
+    "fields": {
+      "displayName": "CURRIC-AB",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEMA",
+    "fields": {
+      "displayName": "OVERSIZEMA",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-DE",
+    "fields": {
+      "displayName": "REF-DE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-DP",
+    "fields": {
+      "displayName": "MEDIA-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-FE",
+    "fields": {
+      "displayName": "STACKS-FE",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-HB2",
+    "fields": {
+      "displayName": "STACKS-HB2",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-HB3",
+    "fields": {
+      "displayName": "STACKS-HB3",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BROWSINGMK",
+    "fields": {
+      "displayName": "BROWSINGMK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ENCYCL-SS",
+    "fields": {
+      "displayName": "ENCYCL-SS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-SV",
+    "fields": {
+      "displayName": "ILL-SV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-DP",
+    "fields": {
+      "displayName": "PERIOD-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RARERM-DN",
+    "fields": {
+      "displayName": "RARERM-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MEDIA-DN",
+    "fields": {
+      "displayName": "MEDIA-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INDEP-LRNG",
+    "fields": {
+      "displayName": "INDEP-LRNG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-CATOII",
+    "fields": {
+      "displayName": "SPC-CATOII",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-DN",
+    "fields": {
+      "displayName": "PERIOD-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATLASES-BD",
+    "fields": {
+      "displayName": "ATLASES-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "MISSING",
+    "fields": {
+      "displayName": "MISSING",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-ED",
+    "fields": {
+      "displayName": "DISPLAY-ED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OCCULT",
+    "fields": {
+      "displayName": "OCCULT",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZEMP",
+    "fields": {
+      "displayName": "OVERSIZEMP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PHONO-HB",
+    "fields": {
+      "displayName": "PHONO-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "WARING",
+    "fields": {
+      "displayName": "WARING",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-RE",
+    "fields": {
+      "displayName": "RESERVE-RE",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "CANCELED",
+    "fields": {
+      "displayName": "CANCELED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BUSREF-BD",
+    "fields": {
+      "displayName": "BUSREF-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ONLINE-DSL",
+    "fields": {
+      "displayName": "ONLINE-DSL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERBND-DN",
+    "fields": {
+      "displayName": "PERBND-DN",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-ED",
+    "fields": {
+      "displayName": "REF-ED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-BD",
+    "fields": {
+      "displayName": "ARCHIVE-BD",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERBND-DP",
+    "fields": {
+      "displayName": "PERBND-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-SV",
+    "fields": {
+      "displayName": "RESERVE-SV",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-EG",
+    "fields": {
+      "displayName": "REF-EG",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DSLSIADISP",
+    "fields": {
+      "displayName": "DSLSIADISP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-EG",
+    "fields": {
+      "displayName": "STACKS-EG",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DSPLAY-ED",
+    "fields": {
+      "displayName": "DSPLAY-ED",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "SPC-WARING",
+    "fields": {
+      "displayName": "SPC-WARING",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ATLASES-AA",
+    "fields": {
+      "displayName": "ATLASES-AA",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "STACKS-EM",
+    "fields": {
+      "displayName": "STACKS-EM",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "WARINGAMER",
+    "fields": {
+      "displayName": "WARINGAMER",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-BU",
+    "fields": {
+      "displayName": "FOLIO-BU",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-DP",
+    "fields": {
+      "displayName": "DISPLAY-DP",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DOC-US",
+    "fields": {
+      "displayName": "DOC-US",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-DN",
+    "fields": {
+      "displayName": "DISPLAY-DN",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-DS",
+    "fields": {
+      "displayName": "REF-DS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZELS",
+    "fields": {
+      "displayName": "OVERSIZELS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "FOLIO-BK",
+    "fields": {
+      "displayName": "FOLIO-BK",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "PERIOD-ED",
+    "fields": {
+      "displayName": "PERIOD-ED",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "OVERSIZELV",
+    "fields": {
+      "displayName": "OVERSIZELV",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ARCHIVE-BK",
+    "fields": {
+      "displayName": "ARCHIVE-BK",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "RESERVE-SL",
+    "fields": {
+      "displayName": "RESERVE-SL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "BIBLES",
+    "fields": {
+      "displayName": "BIBLES",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-DP",
+    "fields": {
+      "displayName": "REF-DP",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DICTIO-NML",
+    "fields": {
+      "displayName": "DICTIO-NML",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "INPROCESS",
+    "fields": {
+      "displayName": "INPROCESS",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "DISPLAY-DS",
+    "fields": {
+      "displayName": "DISPLAY-DS",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REPORTS-HB",
+    "fields": {
+      "displayName": "REPORTS-HB",
+      "holdable": true
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "ILL-SL",
+    "fields": {
+      "displayName": "ILL-SL",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "Z-MISSING",
+    "fields": {
+      "displayName": "Z-MISSING",
+      "holdable": false
+    }
+  },
+  {
+    "resource": "/policy/location",
+    "key": "REF-DN",
+    "fields": {
+      "displayName": "REF-DN",
+      "holdable": true
+    }
+  }
+]

--- a/spec/support/fake_symphony.rb
+++ b/spec/support/fake_symphony.rb
@@ -7,6 +7,14 @@ class FakeSymphony < Sinatra::Base
     json_response 200, "patrons/#{params[:key]}.json"
   end
 
+  get '/symwsbc/catalog/bib/key/:key' do
+    json_response 200, "other/bib_#{params[:key]}.json"
+  end
+
+  get '/symwsbc/policy/location/simpleQuery' do
+    json_response 200, 'other/locations.json'
+  end
+
   get '/symwsbc/policy/itemType/simpleQuery' do
     json_response 200, 'other/item_type_map.json'
   end


### PR DESCRIPTION
I also attempted to create a feature spec that shows a successful hold creation (that I didn't include in this PR of course), however it just redirects to example.com because it is trying reauthenticate when the redirect to holds/result happens. Not sure how to get around this, but it'd be nice to have a feature spec for successful hold creation too.