### PR TITLE
Forces renew session actions to go through same auth pipeline as a br…

### DIFF
--- a/spec/controllers/summaries_controller_spec.rb
+++ b/spec/controllers/summaries_controller_spec.rb
@@ -51,10 +51,14 @@ RSpec.describe SummariesController do
     context 'with a stale session' do
       let(:ping_response) { false }
 
+      before do
+        allow(controller).to receive(:current_user?).and_return(true, false)
+      end
+
       it 'redirects to the application authentication mechanism' do
         get(:index)
 
-        expect(response).to have_http_status '302'
+        expect(response).to redirect_to root_url
       end
     end
   end


### PR DESCRIPTION
…and new user (to the application)

I did force a renew by making `renew_session_token` run and it did redirect properly. In master it does not. Basically I forced it to run by assigning the unless to a var, adding a binding.pry and then running the renew unless that var. Then I just tampered with the var by setting it to false when I wanted it to renew.

```rb
      x = symphony_client.ping?(current_user)
      binding.pry
      renew_session_token unless x
```