### PR TITLE
Caches the version for 5 minutes and refactors class

### DIFF
--- a/app/lib/myaccount_version.rb
+++ b/app/lib/myaccount_version.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
 module MyaccountVersion
-  def self.version
-    retrieve_version
+  def self.resolve_version
+    set_version
+    Redis.current.get 'myaccount_version'
   end
 
   VERSION_CACHE_TIME = 300
   VERSION_NOT_SET_NAME = 'Version could not be determined'
-
-  def self.retrieve_version
-    set_version
-    Redis.current.get 'myaccount_version'
-  end
 
   # `nx: true` means that Redis will only set this value if it doesn't exist. The `ex` option tells Redis when to delete
   # the key.

--- a/app/lib/myaccount_version.rb
+++ b/app/lib/myaccount_version.rb
@@ -2,17 +2,31 @@
 
 module MyaccountVersion
   def self.version
-    version_from_github || 'not set'
+    retrieve_version
+  end
+
+  VERSION_CACHE_TIME = 300
+  VERSION_NOT_SET_NAME = 'Version could not be determined'
+
+  def self.retrieve_version
+    set_version
+    Redis.current.get 'myaccount_version'
+  end
+
+  # `nx: true` means that Redis will only set this value if it doesn't exist. The `ex` option tells Redis when to delete
+  # the key.
+  def self.set_version
+    Redis.current.set 'myaccount_version', version_from_github, ex: VERSION_CACHE_TIME, nx: true
   end
 
   def self.version_from_github
     client = Octokit::Client.new
     releases = client&.releases 'psu-libraries/myaccount'
 
-    return unless good_response? releases
+    return VERSION_NOT_SET_NAME unless good_response? releases
 
     # Strange notation below because this is not a Hash it is a Sawyer::Response
-    releases&.first&.[] :name
+    releases&.first&.[] :name || VERSION_NOT_SET_NAME
   end
 
   # Weirdly, releases returns a String like "{}" OR an Array of Sawyer objects. :shrug:

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -5,7 +5,7 @@ if Settings&.datadog&.on_server
   Datadog.configure do |c|
     c.service = 'myaccount'
     c.env = Settings.datadog.environment
-    c.version = MyaccountVersion::version
+    c.version = MyaccountVersion::resolve_version
     c.use :rails
     c.use :httprb, service_name: 'myaccount-httprb'
     c.use :sidekiq, service_name: 'myaccount-sidekiq'

--- a/spec/lib/myaccount_version_spec.rb
+++ b/spec/lib/myaccount_version_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe MyaccountVersion do
   subject(:myaccount_version) { described_class }
 
+  after do
+    Redis.current.flushall
+  end
+
   describe 'self.version' do
     context 'when the GitHub API is operating as expected' do
       it 'returns the current version according to GitHub' do
@@ -18,7 +22,7 @@ RSpec.describe MyaccountVersion do
       it 'returns the string "not set"' do
         stub_request(:get, 'https://api.github.com/repos/psu-libraries/myaccount/releases')
           .to_return(status: 200, body: '{}', headers: {})
-        expect(myaccount_version.version).to eq 'not set'
+        expect(myaccount_version.version).to eq 'Version could not be determined'
       end
     end
   end

--- a/spec/lib/myaccount_version_spec.rb
+++ b/spec/lib/myaccount_version_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MyaccountVersion do
       it 'returns the current version according to GitHub' do
         stub_request(:any, /api.github.com/).to_rack(FakeGithub)
 
-        expect(myaccount_version.version).to eq 'v0.3.2'
+        expect(myaccount_version.resolve_version).to eq 'v0.3.2'
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe MyaccountVersion do
       it 'returns the string "not set"' do
         stub_request(:get, 'https://api.github.com/repos/psu-libraries/myaccount/releases')
           .to_return(status: 200, body: '{}', headers: {})
-        expect(myaccount_version.version).to eq 'Version could not be determined'
+        expect(myaccount_version.resolve_version).to eq 'Version could not be determined'
       end
     end
   end


### PR DESCRIPTION
I noticed in prod logs that we are getting errors regarding rate limits, so caching for 5 minutes to avoid problems