### PR TITLE
Removes UP College of Medicine pickup location

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,6 @@ pickup_locations:
   UP-PAT: 'Pattee Commons Services Desk'
   UP-ARCHIT: 'Architecture & Landscape Architecture Library, 111 Stuckeman'
   HERSHEY: 'College of Medicine (Hershey)'
-  UP-MEDICAL: 'College of Medicine (University Park Program)'
   DSL-CARL: 'Dickinson Law (Carlisle)'
   DSL-UP: 'Penn State Law (UP)'
   UP-EMS: 'Earth & Min Sci Library 105 Deike'


### PR DESCRIPTION
overriding is at the key level not the array level