### PR TITLE
Adds an error condition and reaction for AJAX requests

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -19,9 +19,9 @@ class CheckoutsController < ApplicationController
     render
   end
 
-  # Handles form submission for renewals in Symphony
+  # Handles form submission for batch checkout renewal requests
   #
-  # PATCH /renewals
+  # PATCH /checkouts/batch
   def batch_update
     checkouts_to_renew.each do |checkout|
       ws_args = { resource: checkout.resource,

--- a/app/javascript/submission_handling/cancel_hold.js
+++ b/app/javascript/submission_handling/cancel_hold.js
@@ -30,16 +30,26 @@ let listenAjaxSuccess = (form) => {
     });
 };
 
+let listenAjaxError = (form) => {
+    form.addEventListener("ajax:error", function () {
+        $('#expiryModal').modal({ "keyboard": false });
+    });
+};
+
 // This is the public function
 let cancelHold = function () {
     // Guard statement
     if (findForm('pending-holds')) {
-        listenSubmit(findForm('pending-holds'));
-        listenAjaxSuccess(findForm('pending-holds'));
+        let pendingHoldsForm = findForm('pending-holds')
+        listenSubmit(pendingHoldsForm);
+        listenAjaxSuccess(pendingHoldsForm);
+        listenAjaxError(pendingHoldsForm);
     }
     if (findForm('active-holds')) {
-        listenSubmit(findForm('active-holds'));
-        listenAjaxSuccess(findForm('active-holds'));
+        let activeHoldsForm = findForm('active-holds')
+        listenSubmit(activeHoldsForm);
+        listenAjaxSuccess(activeHoldsForm);
+        listenAjaxError(activeHoldsForm);
     }
 };
 

--- a/app/javascript/submission_handling/change_pickup_by_date.js
+++ b/app/javascript/submission_handling/change_pickup_by_date.js
@@ -48,6 +48,10 @@ let changePickupByDate = function () {
             });
         }
     });
+
+    findForm('pending-holds').addEventListener("ajax:error", function () {
+        $('#expiryModal').modal({ "keyboard": false });
+    });
 };
 
 export default changePickupByDate;

--- a/app/javascript/submission_handling/change_pickup_library.js
+++ b/app/javascript/submission_handling/change_pickup_library.js
@@ -47,6 +47,10 @@ let changePickupLibrary = function () {
             });
         }
     });
+
+    findForm('pending-holds').addEventListener("ajax:error", function () {
+        $('#expiryModal').modal({ "keyboard": false });
+    });
 };
 
 export default changePickupLibrary;

--- a/app/javascript/submission_handling/renew_checkout.js
+++ b/app/javascript/submission_handling/renew_checkout.js
@@ -46,6 +46,10 @@ let renewCheckout = function () {
             });
         }
     });
+
+    findForm('checkouts').addEventListener("ajax:error", function () {
+        $('#expiryModal').modal({ "keyboard": false });
+    });
 };
 
 

--- a/app/jobs/renew_checkout_job.rb
+++ b/app/jobs/renew_checkout_job.rb
@@ -4,11 +4,9 @@ class RenewCheckoutJob < ApplicationJob
   queue_as :default
 
   def perform(resource:, item_key:, session_token:)
-    response = symphony_client.renew(
-      resource: resource,
-      item_key: item_key,
-      session_token: session_token
-    )
+    response = symphony_client.renew resource: resource,
+                                     item_key: item_key,
+                                     session_token: session_token
 
     case response.status
     when 200
@@ -30,7 +28,6 @@ class RenewCheckoutJob < ApplicationJob
         }
       }.to_json)
     else
-
       processed_error = SirsiResponse::Error.new(error_message_raw: response,
                                                  symphony_client: symphony_client,
                                                  key: item_key,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
 
     <%= render 'layouts/footer' %>
 
+    <%= render 'shared/session_expiry_modal' %>
+
     <div aria-live="polite" aria-atomic="true">
       <div class="toast-insertion-point" style="position: fixed; top: 15px; right: 15px;"></div>
     </div>

--- a/app/views/shared/_session_expiry_modal.html.erb
+++ b/app/views/shared/_session_expiry_modal.html.erb
@@ -1,0 +1,12 @@
+<div class="modal fade" id="expiryModal" tabindex="-1" aria-labelledby="expiryModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><i class="fa fa-exclamation-circle" aria-hidden="true"></i> Session Expired</h5>
+      </div>
+      <div class="modal-body">
+        <p>Your session has expired. Please <%= link_to('refresh your session', root_path) %> and try your request again. If the problems persist, please contact the libraries.</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/sirsi_response/error.html.erb
+++ b/app/views/sirsi_response/error.html.erb
@@ -6,7 +6,7 @@
     </button>
   </div>
   <div class="toast-body">
-    <strong>For <%= title %></strong>
+    <%= render GenericValueWithLabelComponent.new label: 'For', value: title %>
     <p><%= display_error %> Contact your campus library if you need assistance.</p>
   </div>
 </div>

--- a/spec/features/bad_session.rb
+++ b/spec/features/bad_session.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Checkouts', type: :feature do
+  # patron2 below has 2 checkouts
+
+  after do
+    Redis.current.flushall
+  end
+
+  context 'when patron is renewing checkouts' do
+    let(:mock_user) { 'patron2' }
+
+    before do
+      login_as username: 'PATRON2', patron_key: mock_user
+    end
+
+    it 'shows a modal telling the user to start a new session', js: true do
+      visit checkouts_path
+      page.driver.browser.manage.delete_cookie '_myaccount_session'
+      page.check 'renewal_list__2145643:5:1'
+      page.click_button 'Renew'
+
+      expect(page).to have_css '#expiryModal'
+    end
+  end
+
+  context 'when patron is updating holds' do
+    let(:mock_user) { 'patron1' }
+
+    before do
+      login_as username: 'PATRON1', patron_key: mock_user
+      visit holds_path
+    end
+
+    it 'interrupts a change of library with a modal explaining the problem', js: true do
+      page.driver.browser.manage.delete_cookie '_myaccount_session'
+      page.check 'hold_list__3911148'
+      page.select 'Penn State Berks', from: 'pickup_library'
+      page.click_button 'Update Selected Holds'
+
+      expect(page).to have_css '#expiryModal'
+    end
+
+    it 'interrupts a change of pick up by with a modal explaining the problem', js: true do
+      page.driver.browser.manage.delete_cookie '_myaccount_session'
+      page.check 'hold_list__3911148'
+      page.fill_in 'pickup_by_date', with: '01-01-9999'
+      page.click_button 'Update Selected Holds'
+
+      expect(page).to have_css '#expiryModal'
+    end
+
+    it 'interrupts a cancel with a modal explaining the problem', js: true do
+      page.driver.browser.manage.delete_cookie '_myaccount_session'
+      page.check 'hold_list__3911148'
+      page.click_button 'Cancel'
+
+      expect(page).to have_css '#expiryModal'
+    end
+  end
+end


### PR DESCRIPTION
#295 

Handles `422` server responses by quickly displaying a message that session is stale

![Screen Shot 2020-10-22 at 11 28 44 PM](https://user-images.githubusercontent.com/523381/96953139-61146380-14be-11eb-97f1-0e5eda884797.png)

I attempted a feature spec, tried a few variations on:

```rb
# checkouts_spec.rb
context 'when patron\'s session has become stale' do
    it 'shows a modal telling the user to start a new session', js: true do
      page.driver.browser.manage.delete_all_cookies
      page.check 'renewal_list__2145643:5:1'
      page.click_button 'Renew', match: :first
      sleep 3
      expect(page).to have_css '#expiryModal'
    end
  end
```

but not quite there. Might be impossible to test?