### PR TITLE
If default location is not in pickup locations list, add a blank option to force selection

### DIFF
--- a/app/helpers/holds_helper.rb
+++ b/app/helpers/holds_helper.rb
@@ -30,7 +30,8 @@ module HoldsHelper
   def render_pickup_libraries(selected)
     pickup_libraries = Hold::PICKUP_LOCATION_REQUESTED
 
-    if selected.blank?
+    if selected.blank? || !pickup_libraries.value?(selected.to_sym)
+      selected = ''
       default_choice = t('myaccount.hold.update_pickup.pickup_choose_text')
       pickup_libraries = Hash[default_choice, ''].merge(Hold::PICKUP_LOCATION_REQUESTED)
     end

--- a/app/services/place_hold_form/builder.rb
+++ b/app/services/place_hold_form/builder.rb
@@ -35,7 +35,7 @@ class PlaceHoldForm::Builder
       return false if bib_info.call_list.blank?
 
       @call_list = bib_info.call_list.map { |call| Call.new record: call }
-      filter_holdables if @call_list.count > 1
+      filter_holdables if @call_list.count.positive?
 
       @call_list.present?
     end

--- a/spec/helpers/holds_helper_spec.rb
+++ b/spec/helpers/holds_helper_spec.rb
@@ -158,5 +158,10 @@ RSpec.describe HoldsHelper, type: :helper do
       expect(helper.render_pickup_libraries('UP-PAT')).to include '<option selected="selected" value="UP-PAT">'\
                                                                           'Pattee Commons Services Desk</option>'
     end
+
+    it 'returns an html select list with a blank option as selected' do
+      expect(helper.render_pickup_libraries('not-a-pickup-location')).to include '<option selected="selected" '\
+                                            'disabled="disabled" value="">Please choose a pickup location</option>'
+    end
   end
 end

--- a/spec/helpers/holds_helper_spec.rb
+++ b/spec/helpers/holds_helper_spec.rb
@@ -159,8 +159,13 @@ RSpec.describe HoldsHelper, type: :helper do
                                                                           'Pattee Commons Services Desk</option>'
     end
 
-    it 'returns an html select list with a blank option as selected' do
+    it 'returns an html select list with a blank option as selected when selected is not a pickup location' do
       expect(helper.render_pickup_libraries('not-a-pickup-location')).to include '<option selected="selected" '\
+                                            'disabled="disabled" value="">Please choose a pickup location</option>'
+    end
+
+    it 'returns an html select list with a blank option as selected when selected is empty' do
+      expect(helper.render_pickup_libraries('')).to include '<option selected="selected" '\
                                             'disabled="disabled" value="">Please choose a pickup location</option>'
     end
   end


### PR DESCRIPTION
#274 

Additionally, a change to check filter_holdables even if there is only one holding - this only covers withdrawn records and such and users could not get to those records anyway but I think it does not hurt to change the check to cover it.