### PR TITLE
321 multiple emails

### DIFF
--- a/app/views/patrons/edit.html.erb
+++ b/app/views/patrons/edit.html.erb
@@ -36,7 +36,7 @@
   <div class="form-group row">
     <%= label_tag :email, 'Email Address:', class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10 col-lg-5">
-      <%= email_field_tag 'email', @patron.email, class: 'form-control' %>
+      <%= email_field_tag 'email', @patron.email, class: 'form-control', multiple: true %>
       <small class="form-text text-muted">
         How can I receive library notices as text messages? <a href="https://libraries.psu.edu/services/lending-services/about-lending-services/text-messaging-library-notices">More information here</a>.
       </small>


### PR DESCRIPTION
#321 
 

see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-multiple

I was unable to figure out how to get Capybara to detect the little validation tooltips that pop up when you have entered something invalid