### PR TITLE
Upgrades redis gem, fix fatal error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.2.3)
+    redis (4.2.5)
     regexp_parser (1.8.2)
     request_store (1.5.0)
       rack (>= 1.4)


### PR DESCRIPTION
fix for https://app.datadoghq.com/apm/traces?end=1611684984852&paused=false&query=env%3Aproduction%20-status%3Aok&spanID=1726633474243818674&start=1611681384852&storage=hot&streamTraces=true&trace=AQAAAXc_y85ZxaFRoQAAAABBWGNfeTlHVEFBQ2g4elhCd2hlc3BkY1Q&traceID=1429882010751998963

See https://github.com/redis/redis-rb/issues/961


```
NoMethodError: undefined method `bytesize' for nil:NilClass
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/connection/ruby.rb:86:in `block in _write_to_socket'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/connection/ruby.rb:72:in `loop'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/connection/ruby.rb:72:in `_write_to_socket'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/connection/ruby.rb:101:in `block in write'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/connection/ruby.rb:100:in `loop'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/connection/ruby.rb:100:in `write'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/connection/ruby.rb:385:in `write'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:284:in `block in write'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:263:in `io'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:282:in `write'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:240:in `block (3 levels) in process'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:234:in `each'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:234:in `block (2 levels) in process'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:384:in `ensure_connected'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:233:in `block in process'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:320:in `logging'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:232:in `process'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis/client.rb:126:in `call'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/ddtrace-0.42.0/lib/ddtrace/contrib/redis/patcher.rb:46:in `block in call'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/ddtrace-0.42.0/lib/ddtrace/tracer.rb:282:in `trace'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/ddtrace-0.42.0/lib/ddtrace/contrib/redis/patcher.rb:40:in `call'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis.rb:848:in `block in set'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis.rb:69:in `block in synchronize'
/home/ansible_deploy_bot/.rbenv/versions/2.6.5/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis.rb:69:in `synchronize'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/redis-4.2.3/lib/redis.rb:844:in `set'
/data/websites/myaccount/app/jobs/view_checkouts_job.rb:21:in `perform'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activejob-6.0.3.4/lib/active_job/execution.rb:40:in `block in perform_now'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:112:in `block in run_callbacks'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/i18n-1.8.5/lib/i18n.rb:313:in `with_locale'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activejob-6.0.3.4/lib/active_job/translation.rb:9:in `block (2 levels) in <module:Translation>'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `instance_exec'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/core_ext/time/zones.rb:66:in `use_zone'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activejob-6.0.3.4/lib/active_job/timezones.rb:9:in `block (2 levels) in <module:Timezones>'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `instance_exec'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activejob-6.0.3.4/lib/active_job/logging.rb:25:in `block (4 levels) in <module:Logging>'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `block in instrument'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `instrument'
/data/websites/myaccount/vendor/bundle/ruby/2.6.0/gems/activejob-6.0.3.4/lib/active_job/logging.rb:24:in `block (3 levels) in <module:Logging>'
```