### PR TITLE
more sirsi response error codes to exclude from datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -4,6 +4,8 @@ if Settings&.datadog&.on_server
   require 'ddtrace'
 
   SIRSI_RESPONSE_EXCLUDES = [
+    'hatErrorResponse.17',
+    'hatErrorResponse.91',
     'hatErrorResponse.116',
     'hatErrorResponse.141',
     'hatErrorResponse.7703',
@@ -14,7 +16,12 @@ if Settings&.datadog&.on_server
     'hatErrorResponse.722',
     'hatErrorResponse.17286',
     'hatErrorResponse.753',
-    'unhandledException'
+    'unhandledException',
+    'recordNotFound',
+    'acknowledgeRenewalFeeCircPrompt',
+    'invalidPacket',
+    'invalidDateFormat',
+    'permissionDeniedRecordHidden'
   ].freeze
 
   Datadog.configure do |c|


### PR DESCRIPTION
#358 

These response codes are expected and does not need to be reported as error since we do not act on them.