### PR TITLE
don't use profiles

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
 #!/bin/bash
 # runs rspec in test container 
 
-docker-compose run test bundle exec rspec $1
+docker-compose exec test bundle exec rspec $1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,6 @@ services:
   test:
     depends_on:
       - redis
-    profiles:
-      - test
     command: ["sleep" ,"9999"]
     environment:
       SYMWS_URL: 'https://cat-stage.libraries.psu.edu:28443/symwsbc'


### PR DESCRIPTION
The startup time for using `docker-compose run` IMO, was too high, so instead I set it up so that we `exec` right into the already running thing. this helps with things like sprig too if we're using that! 