### PR TITLE
parameterizes more of docker-compose config

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -2,6 +2,8 @@
 # source .envrc
 # OR use direnv https://direnv.net/
 export SYMWS_PIN='some-password'
+export SYMWS_URL='some-url'
+export SYMWS_USERNAME='some-username'
 
 
 ## Ports exposed on the system Change these from the defaults

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,8 +11,8 @@ services:
       - redis
     command: ["sleep" ,"9999"]
     environment:
-      SYMWS_URL: 'https://cat-stage.libraries.psu.edu:28443/symwsbc'
-      SYMWS_USERNAME: 'myaccount'
+      SYMWS_URL: "${SYMWS_URL}"
+      SYMWS_USERNAME: "${SYMWS_USERNAME:-myaccount}"
       REDIS_SIDEKIQ_URI: "redis://redis:6379/1"
       RAILS_ENV: "test"
       REDIS_DATABASE_URI: "redis://redis:6379/2"
@@ -30,8 +30,8 @@ services:
       target: /app/
   sidekiq:
     environment:
-      SYMWS_URL: 'https://cat-stage.libraries.psu.edu:28443/symwsbc'
-      SYMWS_USERNAME: 'myaccount'
+      SYMWS_URL: "${SYMWS_URL}"
+      SYMWS_USERNAME: "${SYMWS_USERNAME:-myaccount}"
       REDIS_SIDEKIQ_URI: "redis://redis:6379/1"
       RAILS_ENV: "development"
       REDIS_DATABASE_URI: "redis://redis:6379/2"
@@ -50,8 +50,8 @@ services:
     command: ["/app/bin/sidekiq"]
   web:
     environment:
-      SYMWS_URL: 'https://cat-stage.libraries.psu.edu:28443/symwsbc'
-      SYMWS_USERNAME: 'myaccount'
+      SYMWS_URL: "${SYMWS_URL}"
+      SYMWS_USERNAME: "${SYMWS_USERNAME:-myaccount}"
       REDIS_SIDEKIQ_URI: "redis://redis:6379/1"
       RAILS_ENV: "development"
       REDIS_DATABASE_URI: "redis://redis:6379/2"


### PR DESCRIPTION
allows the user to change the SYMWS_* variables in their local .envrc file. SYMWS_URL no longer defaults so it must be set in the .envrc file