### PR TITLE
adds dependabot config for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker" 
+    directory: "/" 
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
our base image runs updates on security updates, when an update is found dependabot will issue a PR for update. 