### PR TITLE
allow datadog to be switched via ENV

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if Settings&.datadog&.on_server
+if Settings&.datadog&.enabled
   require 'ddtrace'
 
   SIRSI_RESPONSE_EXCLUDES = [

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,3 @@
 datadog:
-  on_server: true
-  environment: production
+  enabled: <%= ENV.fetch("DD_ENABELD", "true") %>
+  environment: <%= ENV.fetch("DD_ENV", "production") %>


### PR DESCRIPTION
in the config-repo we can set 

```
datadog:
  enabled: [true|false]
```

when switched in the helm chart we set the env appropriately (preview, or production) and then we also set the host to the cluster apm collector

I renamed `on_server` to `enabled` to follow the naming we use elsewhere. I can go either way on that change. 