### PR TITLE
Fix hanging spinners when editing both location and pickup date

### DIFF
--- a/app/javascript/submission_handling/cancel_hold.js
+++ b/app/javascript/submission_handling/cancel_hold.js
@@ -5,6 +5,7 @@ const updateCancelledHold = function (data) {
     if (data.result === 'failure') {
         toggleSpin('hold', data.id, 'hold_status');
     } else {
+        document.querySelector(`#hold_list__${data.id}`).checked = false;
         document.querySelector(`#hold${data.id} .bibitem`).
             innerHTML += data.badge;
         document.querySelector(`#hold${data.id} .hold_status`).innerHTML = data.response;
@@ -27,7 +28,6 @@ let listenAjaxSuccess = (form) => {
         if (responseFromRails(event) === 'Deletion scheduled') {
             allChecked(form).forEach((checkbox) => {
                 renderData(`cancel_hold_${checkbox.value}`, updateCancelledHold);
-                checkbox.checked = false;
             });
 
             document.getElementById('pending_all').checked = false;

--- a/app/javascript/submission_handling/change_pickup_by_date.js
+++ b/app/javascript/submission_handling/change_pickup_by_date.js
@@ -18,6 +18,7 @@ const updatePickupByDate = function (data) {
     if (data.result === 'failure') {
         toggleSpin('hold', data.id, 'pickup-by');
     } else {
+        document.querySelector(`#hold_list__${data.id}`).checked = false;
         document.querySelector(`#hold${data.id} .bibitem`).
             innerHTML += data.response.badge;
         document.querySelector(`#hold${data.id} .pickup-by`).
@@ -49,7 +50,6 @@ let changePickupByDate = function () {
         if (responseFromRails(event) === 'Update scheduled' && pickupByDateInput().value !== '') {
             allChecked(findForm('pending-holds')).forEach((checkbox) => {
                 renderData(`pickup_by_date_${checkbox.value}`, updatePickupByDate, validatePickupByDateChange);
-                checkbox.checked = false;
             });
 
             document.getElementById('pending_all').checked = false;

--- a/app/javascript/submission_handling/change_pickup_library.js
+++ b/app/javascript/submission_handling/change_pickup_library.js
@@ -12,6 +12,7 @@ const updatePickupChange = function (data) {
     if (data.result === 'failure') {
         toggleSpin('hold', data.id, 'pickup_at');
     } else {
+        document.querySelector(`#hold_list__${data.id}`).checked = false;
         document.querySelector(`#hold${data.id} .bibitem`).innerHTML += data.response.badge;
         document.querySelector(`#hold${data.id} .pickup_at`).
             innerHTML = `<span>${data.response.new_value}</span>`;
@@ -44,7 +45,6 @@ let changePickupLibrary = function () {
             pickupChangeSelect().selectedIndex !== defaultSelectIndex) {
             allChecked(findForm('pending-holds')).forEach((checkbox) => {
                 renderData(`pickup_library_${checkbox.value}`, updatePickupChange, validatePickupChange);
-                checkbox.checked = false;
             });
 
             document.getElementById('pending_all').checked = false;

--- a/spec/features/holds_spec.rb
+++ b/spec/features/holds_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe 'Holds', type: :feature do
 
       context 'when the user successfully changes the pickup library of the same hold more than once' do
         it 'success badges gets cleared each time', js: true do
-          page.check 'hold_list__3911148'
+          page.find("input[type='checkbox'][id='hold_list__3911148']").click
           page.select 'Berks Campus Library', from: 'pickup_library'
           page.click_button 'Update Selected Holds'
 
-          expect(page).to have_css '.badge-success', text: 'Successfully changed pickup location', count: 1
+          expect(page.find('.badge-success')).to have_text 'Successfully changed pickup location', count: 1
         end
       end
     end


### PR DESCRIPTION
I have no idea why changing the timing of the uncheck logic makes any difference, but it does.