### PR TITLE
Error log messages 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/support/data/**/*'
 
+Metrics/ClassLength:
+  Exclude:
+  - 'app/services/symphony_client.rb'
+
 Metrics/BlockLength:
   Exclude:
   - 'config/environments/production.rb'

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -23,6 +23,11 @@ class SymphonyClient
                        })
     resp = JSON.parse(response.body)
     session_token = resp['sessionToken']
+
+    if response.status > 200
+      Rails.logger.error("Error Logging In to symphony with message #{resp}")
+    end
+
     get_patron_record(remote_user, session_token)
   end
 
@@ -205,7 +210,11 @@ class SymphonyClient
                                          q: "ALT_ID:#{remote_user.upcase}",
                                          includeFields: '*'
                                        })
-      return nil unless response.status == 200
+
+      if response.status > 200
+        Rails.logger.error("Error Getting Patron record with message #{JSON.parse(response.body)}")
+        return nil
+      end
 
       parsed_response = JSON.parse(response.body)['result'].first
       return nil unless parsed_response

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,9 +3925,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- adds logger messages for symphony responses

Fixes #431 I'm going to put another PR in to add health checks. 

As for what to do when a user is not found, since symphony_client is a service, and not a controller it makes it kind of hard to wire in comms (ala `flash` or `request`) to the user. We may want to refactor `SymphonyClient` before we tackle that one. 


