### PR TITLE
adds symphony healthcheck

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Exclude:
   - 'config/environments/production.rb'
+  - 'config/initializers/warden.rb'
   - 'spec/**/*'
 
 Layout/LineLength:

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -9,10 +9,15 @@ OkComputer::Registry.register(
 )
 
 OkComputer::Registry.register(
+  'symphony',
+  HealthChecks::SymphonyCheck.new
+)
+
+OkComputer::Registry.register(
   'redis',
   OkComputer::RedisCheck.new(url: Settings.redis.database.uri)
 )
 
 # Optional Checks will report failures, but still return 200
 # this will keep a pod from restarting when optional checks are failing
-OkComputer.make_optional %w(redis version)
+OkComputer.make_optional %w(redis version symphony)

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -17,8 +17,8 @@ Warden::Strategies.add(:library_id) do
   end
 
   def authenticate!
-    response = SymphonyClient.new.login(Settings.symws.username, Settings.symws.pin, remote_user) || {}
-
+    _status, session_token = SymphonyClient.new.login(Settings.symws.username, Settings.symws.pin)
+    response = SymphonyClient.new.get_patron_record(remote_user, session_token) || {}
     if response.fetch('patronKey', nil)
       user = {
         username: remote_user,

--- a/lib/healthchecks.rb
+++ b/lib/healthchecks.rb
@@ -2,4 +2,5 @@
 
 module Healthchecks
   require 'healthchecks/version_check'
+  require 'healthchecks/symphony_check'
 end

--- a/lib/healthchecks/symphony_check.rb
+++ b/lib/healthchecks/symphony_check.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module HealthChecks
+  class SymphonyCheck < OkComputer::Check
+    def check
+      client = SymphonyClient.new
+      status, resp = client.login(Settings.symws.username, Settings.symws.pin)
+      if status > 200
+        mark_failure
+        mark_message resp
+      else
+        mark_message 'Successfully Logged In'
+      end
+    end
+  end
+end

--- a/spec/services/symphony_client_spec.rb
+++ b/spec/services/symphony_client_spec.rb
@@ -32,7 +32,21 @@ RSpec.describe SymphonyClient do
     end
 
     it 'logs the user in to symphony' do
-      expect(client.login('fake_user', 'some_password', 'remote_user')).to include 'patronKey' => 'some_patron_key'
+      expect(client.login('fake_user', 'some_password')[1]).to eq('e0b5e1a3e86a399112b9eb893daeacfd')
+    end
+  end
+
+  describe '#get_patron_record' do
+    before do
+      stub_request(:get, "#{Settings.symws.url}/user/patron/search")
+        .with(headers: Settings.symws.headers.to_h.merge('X-Sirs-Sessiontoken': 'token'),
+              query: hash_including(includeFields: '*'))
+        .to_return(status: 200,
+                   body: { result: [{ key: Settings.symws.patron_key, fields: '' }] }.to_json)
+    end
+
+    it 'returns the user' do
+      expect(client.get_patron_record('user', 'token')).to include 'patronKey' => 'some_patron_key'
     end
   end
 


### PR DESCRIPTION
1. breaks out login, and get_patron record
2. returns status, and auth token from `login` this allows us to bubble up errors
3. refactors warden to use this method 
4. makes get_patron_record a public method, too
5. adds /health/symphony endpoint 

I'm not 100% sold on how this is done, but the idea is if there are errors in the application we can look at the logs, or look at /health/symphony or /health/all to see any error message that might bubble up 

Fixes #472 