### PR TITLE
Add ability for patrons to opt into wage garnishment

### DIFF
--- a/app/controllers/lending_policy_controller.rb
+++ b/app/controllers/lending_policy_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class LendingPolicyController < ApplicationController
+  before_action :authenticate_user!
+
+  def accept
+    if patron.eligible_for_wage_garnishment?
+      client = SymphonyClient.new
+      client.accept_lending_policy(patron: patron, session_token: current_user.session_token)
+    end
+
+    # even if the patron is not eligible for wage garnishment (already opted in or some other reason),
+    # just redirect them to the thank you path to avoid further user confusion
+    redirect_to lending_policy_thank_you_path
+  end
+end

--- a/app/javascript/accept_lending_policy.js
+++ b/app/javascript/accept_lending_policy.js
@@ -1,0 +1,14 @@
+const acceptLendingPolicy = () => {
+  const acceptLendingPolicyForm = document.getElementById('accept-lending-policy-form');
+
+  if (acceptLendingPolicyForm) {
+    const checkbox = document.getElementById('accept-lending-policy-checkbox');
+    const button = document.getElementById('accept-lending-policy-submit');
+
+    checkbox.addEventListener('change', (event) => {
+      button.disabled = !event.currentTarget.checked;
+    });
+  }
+};
+
+export default acceptLendingPolicy;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,6 +17,7 @@ import 'bootstrap/dist/js/bootstrap'
 import './styles'
 
 // Application javascript
+import acceptLendingPolicy from '../accept_lending_policy'
 import checkouts from "../view_checkouts"
 import holds from "../view_holds"
 import selectAll from "../select_all";
@@ -31,6 +32,7 @@ document.addEventListener("DOMContentLoaded", function() {
     holds();
     checkouts();
     viewRequestedHolds();
+    acceptLendingPolicy();
 });
 
 

--- a/app/views/lending_policy/show.html.erb
+++ b/app/views/lending_policy/show.html.erb
@@ -1,0 +1,30 @@
+<h1>Acceptance of University Libraries Lending Policy</h1>
+
+<p>
+  The University Libraries has revised its Lending Policy to include the following statement:
+</p>
+
+<p class="mx-5">
+  "For lost materials, if payment is not received for replacement costs within 6 months from notification that the money is due at the Libraries, payment will be payroll deducted for current University employees. For all other fees, if payment is not received within 60 days, payment will be payroll deducted. Additional fees may be charged for this process."
+</p>
+
+<p>
+  The Lending Policy can be seen in its entirety on the Pennsylvania State University Libraries Web Page at <a href="https://libraries.psu.edu/services/borrow-renew/borrowing-privileges">https://libraries.psu.edu/services/borrow-renew/borrowing-privileges</a>. The policy is subject to change without individual notice. Any change in borrower status or address should be reported to the Libraries immediately.
+</p>
+
+<p>
+  By accepting these terms, the applicant agrees to the policies of the Pennsylvania State University Libraries. Please note that acceptance of this policy is necessary to maintain your borrowing privileges.
+</p>
+
+<hr class="my-4" />
+
+<%= form_with url: lending_policy_accept_path, method: :post, id: 'accept-lending-policy-form', local: true do %>
+  <div class="form-group form-check">
+    <input type="checkbox" class="form-check-input" id="accept-lending-policy-checkbox">
+    <label class="form-check-label" for="accept-lending-policy-checkbox">
+      I authorize the Libraries, after appropriate notice, to deduct from my paycheck any fees incurred. Additional fees may be charged for this process. Upon acceptance of this policy, my borrowing privileges will be re-instated.
+    </label>
+  </div>
+
+  <%= submit_tag('Accept & Continue', class: 'btn btn-primary', id: 'accept-lending-policy-submit', disabled: true) %>
+<% end %>

--- a/app/views/lending_policy/thank_you.html.erb
+++ b/app/views/lending_policy/thank_you.html.erb
@@ -1,0 +1,3 @@
+<h1>Thank You</h1>
+
+<p>Thank you for accepting the Libraries' Fee Policy.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ Rails.application.routes.draw do
   delete '/holds/batch', to: 'holds#batch_destroy', as: :holds_batch_destroy
   patch '/checkouts/batch', to: 'checkouts#batch_update', as: :renewals_batch_update
 
+  get 'accept-lending-policy', to: 'lending_policy#show', as: :lending_policy_show
+  post 'accept-lending-policy', to: 'lending_policy#accept', as: :lending_policy_accept
+  get 'accept-lending-policy/thank-you', to: 'lending_policy#thank_you', as: :lending_policy_thank_you
+
   get 'holds/all', to: 'holds#all', as: :holds_all
   get 'holds/result', to: 'holds#result', as: :result
   get 'checkouts/all', to: 'checkouts#all', as: :checkouts_all

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,11 +14,13 @@ symws:
   url: <%= ENV.fetch("SYMWS_URL") { nil } %>
   username: <%= ENV.fetch("SYMWS_USERNAME") { nil } %>
   pin: "<%= ENV.fetch("SYMWS_PIN") { nil } %>"
-  headers:
+  default_headers:
     sd_originating_app_id: cs
     x_sirs_clientID: <%= ENV.fetch("X_SIRS_CLIENTID") { "PSUCATALOG" } %>
     content_type: 'application/json'
     accept: 'application/json'
+  additional_headers:
+    sd_prompt_return: <%= ENV.fetch("SYMWS_EDIT_OVERRIDE") { nil } %>
 redis:
   sidekiq:
     uri: <%= ENV.fetch("REDIS_SIDEKIQ_URI") { "redis://127.0.0.1:6379/1" } %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,7 +1,7 @@
 symws:
   webaccess_url: https://example.com/webaccess
   url: https://example.com/symwsbc
-  headers:
+  default_headers:
       x_sirs_clientID: SymWSTestClient
   login_params:
     login: 'fake_user'

--- a/spec/controllers/lending_policy_controller_spec.rb
+++ b/spec/controllers/lending_policy_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LendingPolicyController do
+  let(:mock_patron) { instance_double(Patron, eligible_for_wage_garnishment?: false) }
+  let(:mock_client) { instance_double(SymphonyClient, ping?: true) }
+
+  context 'with unauthenticated user' do
+    it 'goes to the application root' do
+      get(:show)
+      expect(response).to redirect_to root_url
+    end
+  end
+
+  context 'with an authenticated request' do
+    let(:user) {
+      instance_double(User,
+                      username: 'zzz123',
+                      name: 'Zeke',
+                      patron_key: '1234567',
+                      session_token: 'e0b5e1a3e86a399112b9eb893daeacfd')
+    }
+
+    before do
+      warden.set_user(user)
+      allow(controller).to receive(:patron).and_return(mock_patron)
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(SymphonyClient).to receive(:new).and_return(mock_client)
+      allow(mock_client).to receive(:accept_lending_policy)
+    end
+
+    describe 'GET #show' do
+      it 'renders the show template' do
+        expect(get(:show)).to render_template 'show'
+      end
+    end
+
+    describe 'POST #accept' do
+      context 'when the patron is not eligible for wage garnishment' do
+        it 'renders the thank you template' do
+          expect(post(:accept)).to redirect_to lending_policy_thank_you_path
+        end
+      end
+
+      context 'when the patron is eligible for wage garnishment' do
+        let(:mock_patron) { instance_double(Patron, eligible_for_wage_garnishment?: true) }
+
+        it 'accepts the lending policy' do
+          post(:accept)
+
+          expect(mock_client).to have_received(:accept_lending_policy)
+            .with(patron: mock_patron, session_token: user.session_token)
+        end
+
+        it 'renders the thank you template' do
+          expect(post(:accept)).to redirect_to lending_policy_thank_you_path
+        end
+      end
+    end
+  end
+end

--- a/spec/features/lending_policy_spec.rb
+++ b/spec/features/lending_policy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Lending Policy', type: :feature do
+  let(:mock_user) { 'patron1' }
+
+  before do
+    login_permanently_as username: 'PATRON1', patron_key: mock_user
+    visit lending_policy_show_path
+  end
+
+  after do
+    Warden::Manager._on_request.clear
+    Redis.current.flushall
+  end
+
+  describe 'when the user clicks the checkbox', js: true do
+    it 'toggles the enabled state of the button' do
+      expect(page).to have_button('Accept & Continue', disabled: true)
+
+      page.check 'accept-lending-policy-checkbox'
+
+      expect(page).to have_button('Accept & Continue', disabled: false)
+    end
+  end
+
+  describe 'when the user submits the form', js: true do
+    it 'redirects the user to the thank you page' do
+      page.check 'accept-lending-policy-checkbox'
+      page.click_button 'Accept & Continue'
+
+      expect(page).to have_current_path lending_policy_thank_you_path, ignore_query: true
+    end
+  end
+end

--- a/spec/jobs/view_checkouts_job_spec.rb
+++ b/spec/jobs/view_checkouts_job_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe ViewCheckoutsJob, type: :job do
 
   context 'when SymphonyClient does not respond with 200/OK' do
     before do
-      stub_request(:get, 'https://example.com/symwsbc/user/patron/key/patron2?includeFields=*,circRecordList%7B*,bib%7Btitle,author,callList%7B*%7D%7D,item%7B*,bib%7Bshadowed,title,author%7D,call%7BsortCallNumber,dispCallNumber%7D%7D%7D')
+      stub_request(:get, 'https://example.com/symwsbc/user/patron/key/patron2?includeFields=*,'\
+        'customInformation{patronExtendedInformation{*}},circRecordList%7B*,bib%7Btitle,author,callList%7B*%7D%7D,'\
+        'item%7B*,bib%7Bshadowed,title,author%7D,call%7BsortCallNumber,dispCallNumber%7D%7D%7D')
         .to_return(status: 500, body: '{ "messageList": [{ "message": "A bad thing happened" }] }', headers: {})
     end
 

--- a/spec/jobs/view_holds_job_spec.rb
+++ b/spec/jobs/view_holds_job_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe ViewHoldsJob, type: :job do
 
   context 'when SymphonyClient does not respond with 200/OK' do
     before do
-      stub_request(:get, 'https://example.com/symwsbc/user/patron/key/patron1?includeFields=*,holdRecordList%7B*,bib%7Btitle,author,callList%7B*%7D%7D,item%7B*,bib%7Bshadowed,title,author%7D,call%7BsortCallNumber,dispCallNumber%7D%7D%7D')
+      stub_request(:get, 'https://example.com/symwsbc/user/patron/key/patron1?includeFields=*,'\
+        'customInformation{patronExtendedInformation{*}},holdRecordList%7B*,bib%7Btitle,author,callList%7B*%7D%7D,'\
+        'item%7B*,bib%7Bshadowed,title,author%7D,call%7BsortCallNumber,dispCallNumber%7D%7D%7D')
         .to_return(status: 500, body: '{ "messageList": [{ "message": "A bad thing happened" }] }', headers: {})
     end
 

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe Patron do
       library: {
         key: 'UP-PAT'
       },
+      profile: {
+        key: 'STAFF'
+      },
       address1: [{ resource: '/user/patron/address1',
                    fields: { code: {
                      resource: '/policy/patronAddress1',
@@ -60,7 +63,31 @@ RSpec.describe Patron do
                    fields: { code: {
                      resource: '/policy/patronAddress1',
                      key: 'CITY/STATE'
-                   }, data: 'Jersey Shore, PA' } }]
+                   }, data: 'Jersey Shore, PA' } }],
+      customInformation: [
+        {
+          resource: '/user/patron/customInformation',
+          key: '1',
+          fields: {
+            code: {
+              resource: '/policy/patronExtendedInformation',
+              key: 'PSUACCOUNT'
+            },
+            data: '20050801'
+          }
+        },
+        {
+          resource: '/user/patron/customInformation',
+          key: '19',
+          fields: {
+            code: {
+              resource: '/policy/patronExtendedInformation',
+              key: 'GARNISH-DT'
+            },
+            data: '00000000'
+          }
+        }
+      ]
     }
   end
 
@@ -78,6 +105,10 @@ RSpec.describe Patron do
 
   it 'has a last name' do
     expect(patron.last_name).to eq 'Borrower'
+  end
+
+  it 'has a suffix' do
+    expect(patron.suffix).to eq 'Jr'
   end
 
   it 'has a display name' do
@@ -107,6 +138,18 @@ RSpec.describe Patron do
   it 'has a address' do
     expect(patron.address).to eq({ city_state: 'Jersey Shore, PA', street1: '123 Fake Street', street2: '',
                                    zip: '00000' })
+  end
+
+  it 'has a garnish date' do
+    expect(patron.garnish_date).to eq '00000000'
+  end
+
+  it 'has the correct faculty/staff status' do
+    expect(patron.faculty_or_staff?).to be true
+  end
+
+  it 'has the correct wage garnishment eligibility status' do
+    expect(patron.eligible_for_wage_garnishment?).to be true
   end
 
   context 'with checkouts' do

--- a/spec/support/data/patrons/patron1.json
+++ b/spec/support/data/patrons/patron1.json
@@ -869,6 +869,30 @@
     "middleName": "H",
     "preferredName": "",
     "department": "",
-    "barcode": "999982273"
+    "barcode": "999982273",
+    "customInformation": [
+      {
+        "resource": "/user/patron/customInformation",
+        "key": "1",
+        "fields": {
+          "code": {
+            "resource": "/policy/patronExtendedInformation",
+            "key": "PSUACCOUNT"
+          },
+          "data": "20050801"
+        }
+      },
+      {
+        "resource": "/user/patron/customInformation",
+        "key": "19",
+        "fields": {
+          "code": {
+            "resource": "/policy/patronExtendedInformation",
+            "key": "GARNISH-DT"
+          },
+          "data": "00000000"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
Closes #484.

A new page has been added which allows a patron to accept the University Libraries' Lending Policy, which, if the user is eligible, opts them into wage garnishment.

Currently, only faculty and staff are eligible to opt into this agreement. Opting in sets the patron standing to `OK` and sets the `GARNISH-DT` (garnish date) to the current date.

If you want the override key for testing purposes, it is stored in Vault. Please let me know if you need access.

<img width="1006" alt="Screen Shot 2022-05-03 at 12 30 06 PM" src="https://user-images.githubusercontent.com/639920/166498633-d358ec3f-debd-4bb3-b766-5d5b004f61ea.png">

<img width="985" alt="image" src="https://user-images.githubusercontent.com/639920/166498693-78758b00-4b57-4df5-8b8e-484e956f2158.png">

<img width="948" alt="image" src="https://user-images.githubusercontent.com/639920/166498725-e8cf2158-1eb0-40de-bae3-7dae4e6a2956.png">