### PR TITLE
Summary Page: add link to accept lending policy for eligible patrons

### DIFF
--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -1,7 +1,16 @@
 <% unless patron.standing_human.blank? %>
   <div class="page-section">
     <h3>Alerts: </h3>
-    <div class="ml-4"><%= patron.standing_human %></div>
+    <div class="ml-4">
+      <p><%= patron.standing_human %></p>
+
+      <% if patron.eligible_for_wage_garnishment? %>
+        <p>
+          To unbar your account, please
+          <a href="<%= lending_policy_accept_path %>">accept the University Libraries lending policy</a>.
+        </p>
+      <% end %>
+    </div>
   </div>
 <% end %>
 

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'summaries/index', type: :view do
   let(:fines) { [build(:fine)] }
   let(:patron_standing) { {} }
+  let(:eligible_for_wage_garnishment) { false }
   let(:patron) do
     instance_double(
       Patron,
@@ -12,6 +13,7 @@ RSpec.describe 'summaries/index', type: :view do
       checkouts: [],
       holds: [],
       fines: fines,
+      eligible_for_wage_garnishment?: eligible_for_wage_garnishment,
       **patron_standing
     )
   end
@@ -48,6 +50,25 @@ RSpec.describe 'summaries/index', type: :view do
       render
 
       expect(rendered).to have_css('h3', text: 'Alerts:')
+    end
+
+    context 'when the user is eligible for wage garnishment' do
+      let(:eligible_for_wage_garnishment) { true }
+
+      it 'shows a link to the accept lending policy page' do
+        render
+
+        expect(rendered).to have_link('accept the University Libraries lending policy',
+                                      href: lending_policy_accept_path)
+      end
+    end
+
+    context 'when the user is not eligible for wage garnishment' do
+      it 'does not show a link to the accept lending policy page' do
+        render
+
+        expect(rendered).not_to have_link('accept the University Libraries lending policy')
+      end
     end
   end
 


### PR DESCRIPTION
Closes #490.

For barred patrons who are eligible to opt into wage garnishment, we now show a link in the "Alerts" section to the lending policy so they can accept it and "unbar" their account.

<img width="1194" alt="Screen Shot 2022-05-10 at 12 33 29 PM" src="https://user-images.githubusercontent.com/639920/167678479-c968aaf6-b59b-4c02-9b29-3d8baf1783bb.png">