### PR TITLE
unbar link

### DIFF
--- a/app/jobs/place_holds_job.rb
+++ b/app/jobs/place_holds_job.rb
@@ -30,7 +30,9 @@ class PlaceHoldsJob < ApplicationJob
 
       ApplicationController.render partial: 'holds/results',
                                    layout: false,
-                                   locals: { place_hold_catkey: @catkey, place_hold_results: results_builder.generate, patron: @patron }
+                                   locals: { place_hold_catkey: @catkey,
+                                             place_hold_results: results_builder.generate,
+                                             patron: @patron }
     end
 
     def fetch_patron(patron_key)

--- a/app/jobs/place_holds_job.rb
+++ b/app/jobs/place_holds_job.rb
@@ -30,7 +30,7 @@ class PlaceHoldsJob < ApplicationJob
 
       ApplicationController.render partial: 'holds/results',
                                    layout: false,
-                                   locals: { place_hold_catkey: @catkey, place_hold_results: results_builder.generate }
+                                   locals: { place_hold_catkey: @catkey, place_hold_results: results_builder.generate, patron: @patron }
     end
 
     def fetch_patron(patron_key)

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -143,7 +143,7 @@ class Patron
   end
 
   def barred_by_accept_policy?
-    standing_human == 'The user is BARRED.' && (garnish_date == '00000000' || garnish_date.nil?) 
+    standing_human == 'The user is BARRED.' && (garnish_date == '00000000' || garnish_date.nil?)
   end
 
   private

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -142,6 +142,10 @@ class Patron
     ILL_ELIGIBLE_PROFILES.include?(profile)
   end
 
+  def barred_by_accept_policy?
+    standing_human == 'The user is BARRED.' && (garnish_date == '00000000' || garnish_date.nil?) 
+  end
+
   private
 
     def profile

--- a/app/views/holds/_results.html.erb
+++ b/app/views/holds/_results.html.erb
@@ -9,7 +9,7 @@
         <% end %>
       </ul>
       <div class="card-footer bg-transparent">
-        <% if place_hold_results[:error].first[:error_message] == 'User BARRED' %>
+        <% if patron.standing_human == 'The user is BARRED.' && (patron.garnish_date == '00000000' || patron.garnish_date.nil?) %>
           <p class="text-secondary">To unbar your account, please
           <a href="<%= lending_policy_accept_path %>">accept the University Libraries lending policy</a>.</p>
         <% end %>

--- a/app/views/holds/_results.html.erb
+++ b/app/views/holds/_results.html.erb
@@ -9,7 +9,7 @@
         <% end %>
       </ul>
       <div class="card-footer bg-transparent">
-        <% if patron.standing_human == 'The user is BARRED.' && (patron.garnish_date == '00000000' || patron.garnish_date.nil?) %>
+        <% if patron.barred_by_accept_policy? %>
           <p class="text-secondary">To unbar your account, please
           <a href="<%= lending_policy_accept_path %>">accept the University Libraries lending policy</a>.</p>
         <% end %>

--- a/app/views/holds/_results.html.erb
+++ b/app/views/holds/_results.html.erb
@@ -9,6 +9,10 @@
         <% end %>
       </ul>
       <div class="card-footer bg-transparent">
+        <% if place_hold_results[:error].first[:error_message] == 'User BARRED' %>
+          <p class="text-secondary">To unbar your account, please
+          <a href="<%= lending_policy_accept_path %>">accept the University Libraries lending policy</a>.</p>
+        <% end %>
         <p class="text-secondary"><%= t('myaccount.hold.place_hold.error_html') %></p>
       </div>
     </div>

--- a/spec/features/holds_spec.rb
+++ b/spec/features/holds_spec.rb
@@ -157,4 +157,21 @@ RSpec.describe 'Holds', type: :feature do
       expect(page).not_to have_button 'Cancel Selected Holds'
     end
   end
+
+  context 'when a patron attempts to place a hold but has not accepted the lending policy', js: :true do
+    let(:mock_user3) { 'patron3' }
+
+    before do
+      login_permanently_as username: 'PATRON3', patron_key: mock_user3
+      visit '/holds/new?catkey=24053587'
+    end
+
+    it 'displays a link for the patron to accept lending policy and unbar themselves', js: :true do
+      select 'Pattee and Paterno Library - Commons Services Desk', from: 'pickup_library'
+      fill_in 'pickup_by_date', with: '10-10-2050'
+
+      page.click_button 'Place Hold'
+      expect(page).to have_text 'To unbar your account'
+    end
+  end
 end

--- a/spec/features/holds_spec.rb
+++ b/spec/features/holds_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Holds', type: :feature do
     end
   end
 
-  context 'when a patron attempts to place a hold but has not accepted the lending policy', js: :true do
+  context 'when a patron attempts to place a hold but has not accepted the lending policy', js: true do
     let(:mock_user3) { 'patron3' }
 
     before do
@@ -166,7 +166,7 @@ RSpec.describe 'Holds', type: :feature do
       visit '/holds/new?catkey=24053587'
     end
 
-    it 'displays a link for the patron to accept lending policy and unbar themselves', js: :true do
+    it 'displays a link for the patron to accept lending policy and unbar themselves', js: true do
       select 'Pattee and Paterno Library - Commons Services Desk', from: 'pickup_library'
       fill_in 'pickup_by_date', with: '10-10-2050'
 

--- a/spec/support/data/other/barcode_000080913573.json
+++ b/spec/support/data/other/barcode_000080913573.json
@@ -1,0 +1,75 @@
+{
+    "resource": "/catalog/item",
+    "key": "24053587",
+    "fields": {
+      "itemCategory4": null,
+      "itemCategory3": null,
+      "itemCategory2": null,
+      "itemType": {
+        "resource": "/policy/itemType",
+        "key": "BOOK"
+      },
+      "itemCategory1": null,
+      "itemCategory5": null,
+      "systemModifiedDate": "2020-07-01T15:35:00-04:00",
+      "circulate": true,
+      "currentLocation": {
+        "resource": "/policy/location",
+        "key": "STACKS-EM"
+      },
+      "call": {
+        "resource": "/catalog/call",
+        "key": "24053587",
+        "fields": {
+          "library": {
+            "resource": "/policy/library",
+            "key": "UP-EMS"
+          },
+          "callNumber": "TN805.A1C63",
+          "shadowed": false,
+          "volumetric": " v.39 2017",
+          "sortCallNumber": "TN 000805 .A1C63  V.000039 002017",
+          "dispCallNumber": "TN805.A1C63 v.39 2017",
+          "bib": {
+            "resource": "/catalog/bib",
+            "key": "24053587"
+          },
+          "classification": {
+            "resource": "/policy/classification",
+            "key": "LCPER"
+          },
+          "systemModifiedDate": "2018-07-10T14:47:00-04:00"
+        }
+      },
+      "mediaDesk": null,
+      "pieces": 1,
+      "createdDate": "2018-07-10",
+      "library": {
+        "resource": "/policy/library",
+        "key": "UP-EMS"
+      },
+      "shadowed": false,
+      "permanent": true,
+      "price": {
+        "currencyCode": "USD",
+        "amount": "0.00"
+      },
+      "homeLocation": {
+        "resource": "/policy/location",
+        "key": "STACKS-EM"
+      },
+      "copyNumber": 1,
+      "timesInventoried": 0,
+      "lastInvDate": null,
+      "bib": {
+        "resource": "/catalog/bib",
+        "key": "24053587",
+        "fields": {
+          "shadowed": false,
+          "author": "",
+          "title": "Becoming"
+        }
+      },
+      "barcode": "000080913573"
+    }
+  }

--- a/spec/support/data/other/bib_24053587.json
+++ b/spec/support/data/other/bib_24053587.json
@@ -1,0 +1,78 @@
+{
+  "resource": "/catalog/bib",
+  "key": "24053587",
+  "fields": {
+    "shadowed": false,
+    "author": "Obama, Michelle, 1964-",
+    "titleControlNumber": "l2010000168",
+    "catalogDate": "2018-05-25",
+    "catalogFormat": {
+      "resource": "/policy/catalogFormat",
+      "key": "MARC"
+    },
+    "modifiedDate": "2018-10-03",
+    "systemModifiedDate": "2020-07-01T15:35:00-04:00",
+    "title": "Becoming",
+    "callList": [
+        {
+          "resource": "/catalog/call",
+          "key": "24053587:1",
+          "fields": {
+            "library": {
+              "resource": "/policy/library",
+              "key": "UP-PAT"
+            },
+            "callNumber": "HG2491.J646 2010",
+            "shadowed": false,
+            "volumetric": null,
+            "dispCallNumber": "HG2491.J646 2010",
+            "bib": {
+              "resource": "/catalog/bib",
+              "key": "24053587"
+            },
+            "itemList": [
+              {
+                "resource": "/catalog/item",
+                "key": "24053587:1:1",
+                "fields": {
+                  "call": {
+                    "resource": "/catalog/call",
+                    "key": "24053587:1"
+                  },
+                  "mediaDesk": null,
+                  "itemType": {
+                    "resource": "/policy/itemType",
+                    "key": "BOOK"
+                  },
+                  "library": {
+                    "resource": "/policy/library",
+                    "key": "UP-PAT"
+                  },
+                  "shadowed": false,
+                  "homeLocation": {
+                    "resource": "/policy/location",
+                    "key": "PATERNO-3"
+                  },
+                  "copyNumber": 1,
+                  "bib": {
+                    "resource": "/catalog/bib",
+                    "key": "24053587"
+                  },
+                  "barcode": "000080913573",
+                  "circulate": false,
+                  "currentLocation": {
+                    "resource": "/policy/location",
+                    "key": "CHECKEDOUT"
+                  }
+                }
+              }
+            ],
+            "classification": {
+              "resource": "/policy/classification",
+              "key": "LC"
+            }
+          }
+        }
+    ]
+  }
+}

--- a/spec/support/data/other/symphony_error.json
+++ b/spec/support/data/other/symphony_error.json
@@ -1,0 +1,8 @@
+{ 
+    "messageList": [
+        { 
+            "code": "hatErrorResponse.17",     
+            "message": "User BARRED"
+        }
+    ] 
+}

--- a/spec/support/data/patrons/patron3.json
+++ b/spec/support/data/patrons/patron3.json
@@ -1,0 +1,58 @@
+
+    {
+      "resource": "/user/patron",
+      "key": "patron3",
+      "fields": {
+        "lastName": "LASTNAME",
+        "privilegeExpiresDate": null,
+        "displayName": "SMITH, JANE",
+        "profile": {
+          "resource": "/policy/userProfile",
+          "key": "STAFF"
+        },
+        "groupId": "",
+        "suffix": "",
+        "title": "",
+        "claimsReturnedCount": 0,
+        "alternateID": "ZZZ55555",
+        "firstName": "FIRSTNAME",
+        "standing": {
+          "resource": "/policy/patronStanding",
+          "key": "BARRED"
+        },
+        "library": {
+          "resource": "/policy/library",
+          "key": "UP-PAT"
+        },
+        "usePreferredName": false,
+        "keepCircHistory": "CIRCRULE",
+        "middleName": "H",
+        "preferredName": "",
+        "department": "",
+        "barcode": "999982276",
+        "customInformation": [
+          {
+            "resource": "/user/patron/customInformation",
+            "key": "12",
+            "fields": {
+              "code": {
+                "resource": "/policy/patronExtendedInformation",
+                "key": "PSUACCOUNT"
+              },
+              "data": "STANDARD"
+            }
+          },
+          {
+            "resource": "/user/patron/customInformation",
+            "key": "25",
+            "fields": {
+              "code": {
+                "resource": "/policy/patronExtendedInformation",
+                "key": "GARNISH-DT"
+              },
+              "data": "00000000"
+            }
+          }
+        ]
+      }
+    }

--- a/spec/support/fake_symphony.rb
+++ b/spec/support/fake_symphony.rb
@@ -48,7 +48,13 @@ class FakeSymphony < FakeWebservice
   end
 
   post '/symwsbc/circulation/holdRecord/placeHold' do
-    json_response 200, 'other/place_hold.json'
+    request.body.rewind
+    patron_barcode = json_body(request)['patronBarcode']
+    if patron_barcode == '999982276'
+      json_response 500, 'other/symphony_error.json'
+    else
+      json_response 200, 'other/place_hold.json'
+    end
   end
 
   post '/symwsbc/circulation/holdRecord/cancelHold' do


### PR DESCRIPTION
Display link to accept lending policy when patron's are barred because they have not yet accepted the policy.
Fixes #493 

Due to the way FakeSymphony is set up, I had to create a number of support files in order to create the 500 response. If there is a more efficient way around this, I'd be happy to learn & then refactor. Just let me know!