### PR TITLE
'Recalled' and 'Overdue' checkouts

### DIFF
--- a/app/models/ill_loan.rb
+++ b/app/models/ill_loan.rb
@@ -33,12 +33,22 @@ class IllLoan
       case status
       when 'Customer Notified via E-mail'
         'Available for Pickup'
+      when 'Awaiting Recalled Processing'
+        overdue_display('Recalled')
       when 'Checked Out to Customer'
-        status
+        overdue_display(status)
       when /Renewed by/
-        status
+        overdue_display(status)
       else
         'Processing'
+      end
+    end
+
+    def overdue_display(status_to_display)
+      if due_date.present? && (due_date < Date.today)
+        'Overdue'
+      else
+        status_to_display
       end
     end
 end

--- a/app/services/illiad_client.rb
+++ b/app/services/illiad_client.rb
@@ -65,6 +65,7 @@ class IlliadClient
     def checkouts_query
       CGI.escape("(RequestType eq 'Loan') and " \
                  "((TransactionStatus eq 'Checked Out to Customer') or " \
+                 "(TransactionStatus eq 'Awaiting Recalled Processing') or " \
                  "(TransactionStatus eq 'LST TESTING') or " \
                  "(startswith( TransactionStatus, 'Renewed by')))")
     end
@@ -82,7 +83,6 @@ class IlliadClient
     def holds_statuses
       [
         'Awaiting Copyright Clearance',
-        'Awaiting Request Processing',
         'Awaiting Request Processing',
         'Awaiting Account Validation',
         'In Depth Searching',

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,5 +51,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/spec/models/ill_loan_spec.rb
+++ b/spec/models/ill_loan_spec.rb
@@ -58,28 +58,74 @@ RSpec.describe IllLoan do
 
   describe '#status' do
     context 'when TransactionStatus is "Customer Notified via E-mail"' do
-      it 'returns' do
+      it 'returns "Available for Pickup"' do
         record['TransactionStatus'] = 'Customer Notified via E-mail'
         expect(ill_loan.status).to eq 'Available for Pickup'
       end
     end
 
+    context 'when TransactionStatus is "Awaiting Recalled Processing"' do
+      context 'when due_date is before today' do
+        before do
+          record['DueDate'] = (DateTime.now.yesterday).to_s
+        end
+
+        it 'returns "Overdue"' do
+          record['TransactionStatus'] = 'Awaiting Recalled Processing'
+          expect(ill_loan.status).to eq 'Overdue'
+        end
+      end
+
+      context 'when due_date is after today' do
+        it 'returns "Recalled"' do
+          record['TransactionStatus'] = 'Awaiting Recalled Processing'
+          expect(ill_loan.status).to eq 'Recalled'
+        end
+      end
+    end
+
     context 'when TransactionStatus is "Checked Out to Customer"' do
-      it 'returns' do
-        record['TransactionStatus'] = 'Checked Out to Customer'
-        expect(ill_loan.status).to eq 'Checked Out to Customer'
+      context 'when due_date is before today' do
+        before do
+          record['DueDate'] = (DateTime.now.yesterday).to_s
+        end
+
+        it 'returns "Overdue"' do
+          record['TransactionStatus'] = 'Checked Out to Customer'
+          expect(ill_loan.status).to eq 'Overdue'
+        end
+      end
+
+      context 'when due_date is after today' do
+        it 'returns "Checked Out to Customer' do
+          record['TransactionStatus'] = 'Checked Out to Customer'
+          expect(ill_loan.status).to eq 'Checked Out to Customer'
+        end
       end
     end
 
     context 'when TransactionStatus starts with "Renewed by"' do
-      it 'returns' do
-        record['TransactionStatus'] = 'Renewed by Customer ABC123'
-        expect(ill_loan.status).to eq 'Renewed by Customer ABC123'
+      context 'when due_date is before today' do
+        before do
+          record['DueDate'] = (DateTime.now.yesterday).to_s
+        end
+
+        it 'returns "Overdue"' do
+          record['TransactionStatus'] = 'Renewed by Customer ABC123'
+          expect(ill_loan.status).to eq 'Overdue'
+        end
+      end
+
+      context 'when due_date is after today' do
+        it 'returns the original status' do
+          record['TransactionStatus'] = 'Renewed by Customer ABC123'
+          expect(ill_loan.status).to eq 'Renewed by Customer ABC123'
+        end
       end
     end
 
     context 'when TransactionStatus anything else' do
-      it 'returns' do
+      it 'returns "Processing"' do
         record['TransactionStatus'] = 'Something else'
         expect(ill_loan.status).to eq 'Processing'
       end

--- a/spec/services/illiad_client_spec.rb
+++ b/spec/services/illiad_client_spec.rb
@@ -143,8 +143,9 @@ RSpec.describe IlliadClient do
         stub_request(:get, "#{Settings.illiad.url}/ILLiadWebPlatform/Transaction/UserRequests/" \
                            "test123?$filter=(RequestType%20eq%20'Loan')%20and%20((Transaction" \
                            "Status%20eq%20'Checked%20Out%20to%20Customer')%20or%20(Transactio" \
-                           "nStatus%20eq%20'LST%20TESTING')%20or%20(startswith(%20Transaction" \
-                           "Status,%20'Renewed%20by')))")
+                           "nStatus%20eq%20'Awaiting%20Recalled%20Processing')%20or%20(Transa" \
+                           "ctionStatus%20eq%20'LST%20TESTING')%20or%20(startswith(%20Transac" \
+                           "tionStatus,%20'Renewed%20by')))")
           .with(body: nil,
                 headers: { 'Content-Type': 'application/json', ApiKey: Settings.illiad.api_key })
           .to_return(status: 200, body: return_body)
@@ -162,8 +163,9 @@ RSpec.describe IlliadClient do
         stub_request(:get, "#{Settings.illiad.url}/ILLiadWebPlatform/Transaction/UserRequests/" \
                            "test123?$filter=(RequestType%20eq%20'Loan')%20and%20((Transaction" \
                            "Status%20eq%20'Checked%20Out%20to%20Customer')%20or%20(Transactio" \
-                           "nStatus%20eq%20'LST%20TESTING')%20or%20(startswith(%20Transaction" \
-                           "Status,%20'Renewed%20by')))")
+                           "nStatus%20eq%20'Awaiting%20Recalled%20Processing')%20or%20(Transa" \
+                           "ctionStatus%20eq%20'LST%20TESTING')%20or%20(startswith(%20Transac" \
+                           "tionStatus,%20'Renewed%20by')))")
           .with(body: nil,
                 headers: { 'Content-Type': 'application/json', ApiKey: Settings.illiad.api_key })
           .to_return(status: 400, body: '{"Message":"400 Error"}')
@@ -192,20 +194,19 @@ RSpec.describe IlliadClient do
         stub_request(:get, "#{Settings.illiad.url}/ILLiadWebPlatform/Transaction/UserRequests/test123" \
                            "?$filter=(RequestType%20eq%20'Loan')%20and%20(TransactionStatus%20eq%20'A" \
                            "waiting%20Copyright%20Clearance'%20or%20TransactionStatus%20eq%20'Awaitin" \
-                           "g%20Request%20Processing'%20or%20TransactionStatus%20eq%20'Awaiting%20Req" \
-                           "uest%20Processing'%20or%20TransactionStatus%20eq%20'Awaiting%20Account%20" \
-                           "Validation'%20or%20TransactionStatus%20eq%20'In%20Depth%20Searching'%20or" \
-                           "%20TransactionStatus%20eq%20'Awaiting%20Reshare%20Search'%20or%20Transact" \
-                           "ionStatus%20eq%20'UBorrow%20Find%20Item%20Search'%20or%20TransactionStatu" \
-                           "s%20eq%20'Awaiting%20RAPID%20Request%20Sending'%20or%20TransactionStatus%" \
-                           "20eq%20'Awaiting%20Post%20Receipt%20Processing'%20or%20TransactionStatus%" \
-                           "20eq%20'Request%20Sent'%20or%20TransactionStatus%20eq%20'In%20Transit%20t" \
-                           "o%20Pickup%20Location'%20or%20TransactionStatus%20eq%20'Customer%20Notifi" \
-                           "ed%20via%20E-mail'%20or%20TransactionStatus%20eq%20'Cancelled%20by%20Cust" \
-                           "omer'%20or%20TransactionStatus%20eq%20'Duplicate%20Request%20Review'%20or" \
-                           "%20TransactionStatus%20eq%20'Request%20Available%20Locally'%20or%20Transa" \
-                           "ctionStatus%20eq%20'LST%20TESTING'or%20(startswith(%20TransactionStatus,%" \
-                           "20'STAFF')))")
+                           "g%20Request%20Processing'%20or%20TransactionStatus%20eq%20'Awaiting%20Acc" \
+                           "ount%20Validation'%20or%20TransactionStatus%20eq%20'In%20Depth%20Searchin" \
+                           "g'%20or%20TransactionStatus%20eq%20'Awaiting%20Reshare%20Search'%20or%20T" \
+                           "ransactionStatus%20eq%20'UBorrow%20Find%20Item%20Search'%20or%20Transacti" \
+                           "onStatus%20eq%20'Awaiting%20RAPID%20Request%20Sending'%20or%20Transaction" \
+                           "Status%20eq%20'Awaiting%20Post%20Receipt%20Processing'%20or%20Transaction" \
+                           "Status%20eq%20'Request%20Sent'%20or%20TransactionStatus%20eq%20'In%20Tran" \
+                           "sit%20to%20Pickup%20Location'%20or%20TransactionStatus%20eq%20'Customer%2" \
+                           "0Notified%20via%20E-mail'%20or%20TransactionStatus%20eq%20'Cancelled%20by" \
+                           "%20Customer'%20or%20TransactionStatus%20eq%20'Duplicate%20Request%20Revie" \
+                           "w'%20or%20TransactionStatus%20eq%20'Request%20Available%20Locally'%20or%2" \
+                           "0TransactionStatus%20eq%20'LST%20TESTING'or%20(startswith(%20TransactionS" \
+                           "tatus,%20'STAFF')))")
           .with(body: nil,
                 headers: { 'Content-Type': 'application/json', ApiKey: Settings.illiad.api_key })
           .to_return(status: 200, body: return_body)
@@ -223,20 +224,19 @@ RSpec.describe IlliadClient do
         stub_request(:get, "#{Settings.illiad.url}/ILLiadWebPlatform/Transaction/UserRequests/test123" \
                            "?$filter=(RequestType%20eq%20'Loan')%20and%20(TransactionStatus%20eq%20'A" \
                            "waiting%20Copyright%20Clearance'%20or%20TransactionStatus%20eq%20'Awaitin" \
-                           "g%20Request%20Processing'%20or%20TransactionStatus%20eq%20'Awaiting%20Req" \
-                           "uest%20Processing'%20or%20TransactionStatus%20eq%20'Awaiting%20Account%20" \
-                           "Validation'%20or%20TransactionStatus%20eq%20'In%20Depth%20Searching'%20or" \
-                           "%20TransactionStatus%20eq%20'Awaiting%20Reshare%20Search'%20or%20Transact" \
-                           "ionStatus%20eq%20'UBorrow%20Find%20Item%20Search'%20or%20TransactionStatu" \
-                           "s%20eq%20'Awaiting%20RAPID%20Request%20Sending'%20or%20TransactionStatus%" \
-                           "20eq%20'Awaiting%20Post%20Receipt%20Processing'%20or%20TransactionStatus%" \
-                           "20eq%20'Request%20Sent'%20or%20TransactionStatus%20eq%20'In%20Transit%20t" \
-                           "o%20Pickup%20Location'%20or%20TransactionStatus%20eq%20'Customer%20Notifi" \
-                           "ed%20via%20E-mail'%20or%20TransactionStatus%20eq%20'Cancelled%20by%20Cust" \
-                           "omer'%20or%20TransactionStatus%20eq%20'Duplicate%20Request%20Review'%20or" \
-                           "%20TransactionStatus%20eq%20'Request%20Available%20Locally'%20or%20Transa" \
-                           "ctionStatus%20eq%20'LST%20TESTING'or%20(startswith(%20TransactionStatus,%" \
-                           "20'STAFF')))")
+                           "g%20Request%20Processing'%20or%20TransactionStatus%20eq%20'Awaiting%20Acc" \
+                           "ount%20Validation'%20or%20TransactionStatus%20eq%20'In%20Depth%20Searchin" \
+                           "g'%20or%20TransactionStatus%20eq%20'Awaiting%20Reshare%20Search'%20or%20T" \
+                           "ransactionStatus%20eq%20'UBorrow%20Find%20Item%20Search'%20or%20Transacti" \
+                           "onStatus%20eq%20'Awaiting%20RAPID%20Request%20Sending'%20or%20Transaction" \
+                           "Status%20eq%20'Awaiting%20Post%20Receipt%20Processing'%20or%20Transaction" \
+                           "Status%20eq%20'Request%20Sent'%20or%20TransactionStatus%20eq%20'In%20Tran" \
+                           "sit%20to%20Pickup%20Location'%20or%20TransactionStatus%20eq%20'Customer%2" \
+                           "0Notified%20via%20E-mail'%20or%20TransactionStatus%20eq%20'Cancelled%20by" \
+                           "%20Customer'%20or%20TransactionStatus%20eq%20'Duplicate%20Request%20Revie" \
+                           "w'%20or%20TransactionStatus%20eq%20'Request%20Available%20Locally'%20or%2" \
+                           "0TransactionStatus%20eq%20'LST%20TESTING'or%20(startswith(%20TransactionS" \
+                           "tatus,%20'STAFF')))")
           .with(body: nil,
                 headers: { 'Content-Type': 'application/json', ApiKey: Settings.illiad.api_key })
           .to_return(status: 400, body: '{"Message":"400 Error"}')


### PR DESCRIPTION
Adds 'Awaiting Recalled Processing' transaction status to checkouts query.  This displays as 'Recalled'.  Removes duplicate query from holds query.  Adds logic the displays for checkouts that displays 'Overdue' if we are past the due date.  Tests for all of this.