### PR TITLE
change ILL hold defaults

### DIFF
--- a/app/components/place_hold_date_component.rb
+++ b/app/components/place_hold_date_component.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 class PlaceHoldDateComponent < ViewComponent::Base
-  def initialize(validate_pickup_info: true, make_default: true)
+  def initialize(validate_pickup_info: true, make_default: true, is_ill: false)
     @make_default = make_default
     @validate_pickup_info = validate_pickup_info
+    @is_ill = is_ill
   end
 
   def default_pickup_by_date
     return '' unless make_default
 
-    DateTime.now.+(14.days).strftime('%Y-%m-%d')
+    if is_ill
+      DateTime.now.+(45.days).strftime('%Y-%m-%d')
+    else
+      DateTime.now.+(14.days).strftime('%Y-%m-%d')
+    end
   end
 
   def minimum_pickup_by_date
@@ -18,5 +23,5 @@ class PlaceHoldDateComponent < ViewComponent::Base
 
   private
 
-    attr_reader :make_default, :validate_pickup_info
+    attr_reader :make_default, :validate_pickup_info, :is_ill
 end

--- a/app/views/holds/_form_inputs.html.erb
+++ b/app/views/holds/_form_inputs.html.erb
@@ -2,4 +2,4 @@
 <%= select_tag 'pickup_library', render_pickup_libraries(selected),
                class: 'custom-select', data: 'pickup-location', required: validate_pickup_info %>
 
-<%= render PlaceHoldDateComponent.new make_default: make_default, validate_pickup_info: validate_pickup_info %>
+<%= render PlaceHoldDateComponent.new make_default: make_default, validate_pickup_info: validate_pickup_info, is_ill: is_ill %>

--- a/app/views/holds/_holds_not_ready_table.html.erb
+++ b/app/views/holds/_holds_not_ready_table.html.erb
@@ -44,7 +44,8 @@
                 <h4>Edit Selected Holds</h4>
                 <%= render partial: 'holds/form_inputs', locals: { selected: '',
                                                                    validate_pickup_info: false,
-                                                                   make_default: false } %>
+                                                                   make_default: false,
+                                                                   is_ill: false } %>
                 <br>
                   <%= submit_tag('Update Selected Holds', class: 'btn btn-primary deflatten', formmethod: 'PATCH', data: { disable_with: 'Please wait...' }) %>
               </div>

--- a/app/views/holds/new.html.erb
+++ b/app/views/holds/new.html.erb
@@ -10,7 +10,8 @@
   <%= hidden_field_tag :catkey, params[:catkey] %>
   <%= render partial: 'holds/form_inputs', locals: { selected: @place_hold_form_params[:pickup_library],
                                                      validate_pickup_info: true,
-                                                     make_default: true } %>
+                                                     make_default: true,
+                                                     is_ill: false } %>
   <%= render PlaceHoldCheckboxWrapperComponent.new volumetric_calls: @place_hold_form_params[:volumetric_calls] %>
   <%= submit_tag('Place Hold', class: 'btn btn-info') %>
   <%= link_to 'Cancel', Rails.application.config.catalog_url + @place_hold_form_params[:catkey], class: 'btn btn-danger' %>

--- a/app/views/ill/new.html.erb
+++ b/app/views/ill/new.html.erb
@@ -12,15 +12,15 @@
 <%= form_with url: '/ill', local: true, method: :post do %>
     <%= hidden_field_tag :catkey, params[:catkey] %>
 
-    <%= render PlaceHoldDateComponent.new %>
+    <%= render PlaceHoldDateComponent.new is_ill: true %>
 
     <p class="form-group">
-      <%= check_box_tag :accept_alternate_edition, true, true %>
+      <%= check_box_tag :accept_alternate_edition, true, false %>
       <%= label_tag :accept_alternate_edition, t('myaccount.ill.new_loan.accept_alternate_edition') %>
     </p>
 
     <p class="form-group">
-      <%= check_box_tag :accept_ebook, true, true %>
+      <%= check_box_tag :accept_ebook, true, false %>
       <%= label_tag :accept_ebook, t('myaccount.ill.new_loan.accept_ebook') %>
     </p>
 

--- a/spec/views/holds/_form_inputs.html.erb_spec.rb
+++ b/spec/views/holds/_form_inputs.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'holds/_form_inputs.html.erb' do
     before do
       render partial: 'holds/form_inputs.html.erb', locals: { validate_pickup_info: true,
                                                               make_default: true,
+                                                              is_ill: false,
                                                               selected: 'UP-PAT' }
     end
 
@@ -26,6 +27,7 @@ RSpec.describe 'holds/_form_inputs.html.erb' do
       input = page.find('input#pickup_by_date')
 
       expect(input['required']).not_to be_nil
+      expect(input['value']).to eq DateTime.now.+(14.days).strftime('%Y-%m-%d')
     end
 
     it 'will mark pickup library as required' do
@@ -39,6 +41,7 @@ RSpec.describe 'holds/_form_inputs.html.erb' do
     before do
       render partial: 'holds/form_inputs.html.erb', locals: { validate_pickup_info: false,
                                                               make_default: false,
+                                                              is_ill: false,
                                                               selected: 'UP-PAT' }
     end
 

--- a/spec/views/ill/new.html.erb_spec.rb
+++ b/spec/views/ill/new.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'ill/new.html.erb' do
     title: 'How to Eat More Pizza',
     author: 'Samantha Smith'
   } }
+  let(:page) { Capybara.string(rendered) }
 
   before do
     assign(:place_loan_form_params, form_params)
@@ -23,9 +24,22 @@ RSpec.describe 'ill/new.html.erb' do
     expect(rendered).to have_content('Author: Samantha Smith')
   end
 
-  xit 'renders not needed after date'
-  xit 'renders alternate edition checkbox'
-  xit 'renders ebook checkbox'
+  it 'renders not needed after date' do
+    expect(rendered).to include DateTime.now.+(45.days).strftime('%Y-%m-%d')
+  end
+
+  it 'renders alternate edition checkbox' do
+    input = page.find('input#accept_alternate_edition')
+
+    expect(input['type']).to eq 'checkbox'
+  end
+
+  it 'renders ebook checkbox' do
+    input = page.find('input#accept_ebook')
+
+    expect(input['type']).to eq 'checkbox'
+  end
+
   xit 'renders notes checkbox'
 
   it 'provides a way to Cancel and go back to the catalog' do


### PR DESCRIPTION
Fixes #571 
For ILL holds, default not needed after date extended to 45 days, and accept ebook and accept alternate edition are now unchecked by default.