### PR TITLE
add ILLiad materials to summary counts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,7 @@ RSpec/MultipleMemoizedHelpers:
   Exclude:
     - 'spec/controllers/holds_controller_spec.rb'
     - 'spec/controllers/ill_controller_spec.rb'
+    - 'spec/features/summaries_spec.rb'
     - 'spec/services/**/*'
 
 Rails/I18nLocaleTexts:

--- a/app/controllers/ill_controller.rb
+++ b/app/controllers/ill_controller.rb
@@ -88,8 +88,8 @@ class IllController < ApplicationController
       @bib_info ||= Bib.new(SymphonyClientParser::parsed_response(
                               symphony_client,
                               :get_bib_info,
-                              params[:catkey],
-                              current_user.session_token
+                              catkey: params[:catkey],
+                              session_token: current_user.session_token
                             ))
     end
 

--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -9,11 +9,42 @@ class SummariesController < ApplicationController
   # GET /summaries.json
   def index
     @patron = patron
+    @illiad_holds = IlliadClient.new.send("get_loan_#{:holds}", current_user.username)
+    @illiad_checkouts = IlliadClient.new.send("get_loan_#{:checkouts}", current_user.username)
+    @ill_recalled = ill_recalled
+    @ill_overdue = ill_overdue
+    @ill_ready_for_pickup = ill_ready_for_pickup
   end
 
   private
 
     def item_details
       { all: true }
+    end
+
+    def ill_recalled
+      count = 0
+      @illiad_checkouts.each_with_index do |hold|
+        count += 1 if hold.status == 'Recalled, Please Return ASAP'
+      end
+      count
+    end
+
+    def ill_overdue
+      count = 0
+      @illiad_checkouts.each_with_index do |hold|
+        if hold.due_date.present?
+          count += 1 if hold.due_date < Time.now
+        end
+      end
+      count
+    end
+
+    def ill_ready_for_pickup
+      count = 0
+      @illiad_holds.each_with_index do |hold|
+        count += 1 if hold.status == 'Available for Pickup'
+      end
+      count
     end
 end

--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -9,42 +9,12 @@ class SummariesController < ApplicationController
   # GET /summaries.json
   def index
     @patron = patron
-    @illiad_holds = IlliadClient.new.send("get_loan_#{:holds}", current_user.username)
-    @illiad_checkouts = IlliadClient.new.send("get_loan_#{:checkouts}", current_user.username)
-    @ill_recalled = ill_recalled
-    @ill_overdue = ill_overdue
-    @ill_ready_for_pickup = ill_ready_for_pickup
+    @illiad_response = IlliadResponse.new(current_user.username)
   end
 
   private
 
     def item_details
       { all: true }
-    end
-
-    def ill_recalled
-      count = 0
-      @illiad_checkouts.each_with_index do |hold|
-        count += 1 if hold.status == 'Recalled, Please Return ASAP'
-      end
-      count
-    end
-
-    def ill_overdue
-      count = 0
-      @illiad_checkouts.each_with_index do |hold|
-        if hold.due_date.present?
-          count += 1 if hold.due_date < Time.now
-        end
-      end
-      count
-    end
-
-    def ill_ready_for_pickup
-      count = 0
-      @illiad_holds.each_with_index do |hold|
-        count += 1 if hold.status == 'Available for Pickup'
-      end
-      count
     end
 end

--- a/app/services/illiad_response.rb
+++ b/app/services/illiad_response.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# HTTP response wrapper for requests to ILLiad Web Platform API
+class IlliadResponse
+  def initialize(current_user_username)
+    @current_user_username = current_user_username
+  end
+
+  def illiad_holds
+    holds = IlliadClient.new.send("get_loan_#{:holds}", @current_user_username)
+    (holds.presence || [])
+  end
+
+  def illiad_checkouts
+    checkouts = IlliadClient.new.send("get_loan_#{:checkouts}", @current_user_username)
+    (checkouts.presence || [])
+  end
+
+  def ill_recalled
+    count = 0
+    illiad_checkouts.each do |hold|
+      count += 1 if hold.status == 'Recalled, Please Return ASAP'
+    end
+    count
+  end
+
+  def ill_overdue
+    count = 0
+    illiad_checkouts.each do |hold|
+      if hold.due_date.present? && (hold.due_date < Time.now)
+        count += 1
+      end
+    end
+    count
+  end
+
+  def ill_ready_for_pickup
+    count = 0
+    illiad_holds.each do |hold|
+      count += 1 if hold.status == 'Available for Pickup'
+    end
+    count
+  end
+end

--- a/app/services/symphony_client_parser.rb
+++ b/app/services/symphony_client_parser.rb
@@ -2,9 +2,8 @@
 
 # Responsible for parsing SymphonyClient responses.
 class SymphonyClientParser
-  def self.parsed_response(symphony_client, symphony_call, *params)
-    kwargs = params.first.nil? ? {} : params.first
-    client_response = symphony_client.send(symphony_call, **kwargs)
-    JSON.parse client_response.body
+  def self.parsed_response(symphony_client, symphony_call, **params)
+    client_response = symphony_client.send(symphony_call, **params)
+    JSON.parse(client_response.body)
   end
 end

--- a/app/services/symphony_client_parser.rb
+++ b/app/services/symphony_client_parser.rb
@@ -2,8 +2,9 @@
 
 # Responsible for parsing SymphonyClient responses.
 class SymphonyClientParser
-  def self.parsed_response(symphony_client, symphony_call, **params)
-    client_response = symphony_client.send(symphony_call, **params)
+  def self.parsed_response(symphony_client, symphony_call, *params)
+    kwargs = params.first.nil? ? {} : params.first
+    client_response = symphony_client.send(symphony_call, **kwargs)
     JSON.parse client_response.body
   end
 end

--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -29,21 +29,21 @@
                                             count_term: 'You owe') %>
 
       <%= render DashboardItemComponent.new(model: 'Checkouts',
-                                            count: patron.checkouts&.length,
+                                            count: (patron.checkouts&.length + @illiad_checkouts.count),
                                             count_term: 'Total checked out',
                                             items: [
-                                              { label: 'recalled', count: patron.checkouts&.select(&:recalled?)&.length },
-                                              { label: 'overdue', count: patron.checkouts&.select(&:overdue?)&.length }
+                                              { label: 'recalled', count: (patron.checkouts&.select(&:recalled?)&.length + @ill_recalled) },
+                                              { label: 'overdue', count: (patron.checkouts&.select(&:overdue?)&.length + @ill_overdue) }
                                             ]) %>
 
       <%= render DashboardItemComponent.new(model: 'Holds',
-                                            count: patron.holds&.length,
+                                            count: (patron.holds&.length + @illiad_holds.count),
                                             count_term: 'Total holds',
                                             items: [
                                               { label: 'ready for pickup',
-                                                count: patron.holds&.select(&:ready_for_pickup?)&.length },
+                                                count: (patron.holds&.select(&:ready_for_pickup?)&.length + @ill_ready_for_pickup)},
                                               { label: 'not yet ready for pickup',
-                                                count: patron.holds&.reject(&:ready_for_pickup?)&.length }
+                                                count: (patron.holds&.reject(&:ready_for_pickup?)&.length + @illiad_holds.count - @ill_ready_for_pickup) }
                                             ]) %>
     </div>
   <% end %>

--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -29,21 +29,21 @@
                                             count_term: 'You owe') %>
 
       <%= render DashboardItemComponent.new(model: 'Checkouts',
-                                            count: (patron.checkouts&.length + @illiad_checkouts.count),
+                                            count: (@illiad_checkouts.count + (patron.checkouts.present? ? patron.checkouts&.length : 0) ),
                                             count_term: 'Total checked out',
                                             items: [
-                                              { label: 'recalled', count: (patron.checkouts&.select(&:recalled?)&.length + @ill_recalled) },
-                                              { label: 'overdue', count: (patron.checkouts&.select(&:overdue?)&.length + @ill_overdue) }
+                                              { label: 'recalled', count: ( @ill_recalled + (patron.checkouts.present? ? patron.checkouts&.select(&:recalled?)&.length : 0)) },
+                                              { label: 'overdue', count: (@ill_overdue + (patron.checkouts.present? ? patron.checkouts&.select(&:overdue?)&.length : 0)) }
                                             ]) %>
 
       <%= render DashboardItemComponent.new(model: 'Holds',
-                                            count: (patron.holds&.length + @illiad_holds.count),
+                                            count: (@illiad_holds.count + (patron.holds.present? ? patron.holds&.length : 0)),
                                             count_term: 'Total holds',
                                             items: [
                                               { label: 'ready for pickup',
-                                                count: (patron.holds&.select(&:ready_for_pickup?)&.length + @ill_ready_for_pickup)},
+                                                count: (@ill_ready_for_pickup + (patron.holds.present? ? patron.holds&.select(&:ready_for_pickup?)&.length : 0))},
                                               { label: 'not yet ready for pickup',
-                                                count: (patron.holds&.reject(&:ready_for_pickup?)&.length + @illiad_holds.count - @ill_ready_for_pickup) }
+                                                count: (@illiad_holds.count - @ill_ready_for_pickup + (patron.holds.present? ? patron.holds&.reject(&:ready_for_pickup?)&.length : 0)) }
                                             ]) %>
     </div>
   <% end %>

--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -29,21 +29,21 @@
                                             count_term: 'You owe') %>
 
       <%= render DashboardItemComponent.new(model: 'Checkouts',
-                                            count: (@illiad_checkouts.count + (patron.checkouts.present? ? patron.checkouts&.length : 0) ),
+                                            count: (illiad_response.illiad_checkouts.count + (patron.checkouts.present? ? patron.checkouts&.length : 0)),
                                             count_term: 'Total checked out',
                                             items: [
-                                              { label: 'recalled', count: ( @ill_recalled + (patron.checkouts.present? ? patron.checkouts&.select(&:recalled?)&.length : 0)) },
-                                              { label: 'overdue', count: (@ill_overdue + (patron.checkouts.present? ? patron.checkouts&.select(&:overdue?)&.length : 0)) }
+                                              { label: 'recalled', count: (illiad_response.ill_recalled + (patron.checkouts.present? ? patron.checkouts&.select(&:recalled?)&.length : 0)) },
+                                              { label: 'overdue', count: (illiad_response.ill_overdue + (patron.checkouts.present? ? patron.checkouts&.select(&:overdue?)&.length : 0)) }
                                             ]) %>
 
       <%= render DashboardItemComponent.new(model: 'Holds',
-                                            count: (@illiad_holds.count + (patron.holds.present? ? patron.holds&.length : 0)),
+                                            count: (illiad_response.illiad_holds.count + (patron.holds.present? ? patron.holds&.length : 0)),
                                             count_term: 'Total holds',
                                             items: [
                                               { label: 'ready for pickup',
-                                                count: (@ill_ready_for_pickup + (patron.holds.present? ? patron.holds&.select(&:ready_for_pickup?)&.length : 0))},
+                                                count: (illiad_response.ill_ready_for_pickup + (patron.holds.present? ? patron.holds&.select(&:ready_for_pickup?)&.length : 0)) },
                                               { label: 'not yet ready for pickup',
-                                                count: (@illiad_holds.count - @ill_ready_for_pickup + (patron.holds.present? ? patron.holds&.reject(&:ready_for_pickup?)&.length : 0)) }
+                                                count: (illiad_response.illiad_holds.count - illiad_response.ill_ready_for_pickup + (patron.holds.present? ? patron.holds&.reject(&:ready_for_pickup?)&.length : 0)) }
                                             ]) %>
     </div>
   <% end %>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -1,1 +1,1 @@
-<%= render 'summary', patron: patron %>
+<%= render 'summary', patron: patron, illiad_response: @illiad_response %>

--- a/spec/controllers/summaries_controller_spec.rb
+++ b/spec/controllers/summaries_controller_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe SummariesController do
 
   before do
     allow(SymphonyClient).to receive(:new).and_return(mock_client)
+    stub_request(:get, %r{https://illiad.illiad/illiad/ILLiadWebPlatform/Transaction/UserRequests})
+      .with(headers: {
+              'Apikey' => '1234',
+              'Connection' => 'close',
+              'Content-Type' => 'application/json',
+              'Host' => 'illiad.illiad',
+              'User-Agent' => 'http.rb/4.4.1'
+            })
+      .to_return(status: 200, body: '[]', headers: {})
   end
 
   context 'with an unauthenticated request' do

--- a/spec/features/ask_a_librarian_spec.rb
+++ b/spec/features/ask_a_librarian_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe 'Ask a librarian' do
   let(:mock_user) { 'patron2' }
 
   before do
+    stub_request(:get, %r{https://illiad.illiad/illiad/ILLiadWebPlatform/Transaction/UserRequests})
+      .with(headers: {
+              'Apikey' => '1234',
+              'Connection' => 'close',
+              'Content-Type' => 'application/json',
+              'Host' => 'illiad.illiad',
+              'User-Agent' => 'http.rb/4.4.1'
+            })
+      .to_return(status: 200, body: '[]', headers: {})
     login_as username: 'PATRON2', patron_key: mock_user
   end
 

--- a/spec/features/session_life_spec.rb
+++ b/spec/features/session_life_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe 'Session cookies' do
   let(:mock_user) { 'patron1' }
 
   before do
+    stub_request(:get, %r{https://illiad.illiad/illiad/ILLiadWebPlatform/Transaction/UserRequests})
+      .with(headers: {
+              'Apikey' => '1234',
+              'Connection' => 'close',
+              'Content-Type' => 'application/json',
+              'Host' => 'illiad.illiad',
+              'User-Agent' => 'http.rb/4.4.1'
+            })
+      .to_return(status: 200, body: '[]', headers: {})
     login_permanently_as username: 'PATRON1', patron_key: mock_user
     visit root_path
   end

--- a/spec/features/summaries_spec.rb
+++ b/spec/features/summaries_spec.rb
@@ -3,22 +3,87 @@
 require 'rails_helper'
 
 RSpec.describe 'Summaries' do
-  # patron1 below has 1 hold ready for pick and 4 holds not yet ready for pickup
-  let(:mock_user) { 'patron1' }
-
-  before do
-    login_permanently_as username: 'PATRON1', patron_key: mock_user
-  end
 
   after do
     Warden::Manager._on_request.clear
   end
 
   describe 'the summaries page', js: true do
-    it 'is accessible' do
-      visit summaries_path
+    context 'when there are no ILLiad checkouts or holds' do
+      let(:mock_user) { 'patron1' }
+      let(:return_body) { '[]' }
+      before do
+          stub_request(:get, %r{https://illiad.illiad/illiad/ILLiadWebPlatform/Transaction/UserRequests})
+            .with(
+              headers: {
+                'Apikey' => '1234',
+                'Connection' => 'close',
+                'Content-Type' => 'application/json',
+                'Host' => 'illiad.illiad',
+                'User-Agent' => 'http.rb/4.4.1'
+              }
+            )
+            .to_return(status: 200, body: return_body, headers: {})
+        login_permanently_as username: 'PATRON1', patron_key: mock_user
+      end
 
-      expect(page).to be_accessible
+      it 'is accessible' do
+        visit summaries_path
+
+        expect(page).to be_accessible
+      end
+    end
+
+    context 'when a user has two ILLiad checkouts' do
+      let(:hold_return_body) do
+        '[{"TransactionNumber":123456, "Username":"test123", "RequestType":"Loan",
+            "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 4",
+            "LoanPublisher":null, "LoanPlace":null, "TransactionStatus":"Awaiting Request Processing"},
+          {"TransactionNumber":123457, "Username":"test123", "RequestType":"Loan",
+            "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 5", "LoanPublisher":null,
+            "LoanPlace":null, "TransactionStatus":"Customer Notified via E-Mail"}]'
+      end
+      let(:checkout_return_body) do
+        '[{"TransactionNumber":123456, "Username":"test123", "RequestType":"Loan",
+           "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 1",
+           "LoanPublisher":null, "LoanPlace":null, "TransactionStatus":"Checked Out to Customer"},
+          {"TransactionNumber":123457, "Username":"test123", "RequestType":"Loan",
+            "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 2", "LoanPublisher":null,
+            "LoanPlace":null, "TransactionStatus":"Awaiting Recalled Processing", "DueDate":"2023-02-28T00:00:00"},
+          {"TransactionNumber":123457, "Username":"test123", "RequestType":"Loan",
+            "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 3", "LoanPublisher":null,
+            "LoanPlace":null, "TransactionStatus":"Checked Out to Customer"}]'
+      end
+      # patron2 below has 2 checkouts (1 recalled, 1 overdue) and no holds
+      let(:mock_user2) { 'patron2' }
+      let(:hold) { "ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28TransactionStatus+eq+%27Awaiting+Copyright+Clearance%27+or+TransactionStatus+eq+%27Awaiting+Request+Processing%27+or+TransactionStatus+eq+%27Awaiting+Account+Validation%27+or+TransactionStatus+eq+%27In+Depth+Searching%27+or+TransactionStatus+eq+%27Awaiting+Reshare+Search%27+or+TransactionStatus+eq+%27UBorrow+Find+Item+Search%27+or+TransactionStatus+eq+%27Awaiting+RAPID+Request+Sending%27+or+TransactionStatus+eq+%27Awaiting+Post+Receipt+Processing%27+or+TransactionStatus+eq+%27Request+Sent%27+or+TransactionStatus+eq+%27In+Transit+to+Pickup+Location%27+or+TransactionStatus+eq+%27Customer+Notified+via+E-Mail%27+or+TransactionStatus+eq+%27Cancelled+by+Customer%27+or+TransactionStatus+eq+%27Duplicate+Request+Review%27+or+TransactionStatus+eq+%27Request+Available+Locally%27+or+TransactionStatus+eq+%27LST+TESTING%27or+%28startswith%28+TransactionStatus%2C+%27STAFF%27%29%29%29" }
+      let(:checkout) { "ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28%28TransactionStatus+eq+%27Checked+Out+to+Customer%27%29+or+%28TransactionStatus+eq+%27Awaiting+Recalled+Processing%27%29+or+%28TransactionStatus+eq+%27LST+TESTING%27%29+or+%28startswith%28+TransactionStatus%2C+%27Renewed+by%27%29%29%29" }
+      let(:headers) { {
+        'Apikey' => '1234',
+        'Connection' => 'close',
+        'Content-Type' => 'application/json',
+        'Host' => 'illiad.illiad',
+        'User-Agent' => 'http.rb/4.4.1'
+      } }
+      before do
+        stub_request(:get, "https://illiad.illiad/illiad/#{hold}")
+          .with( headers: headers )
+          .to_return(status: 200, body: hold_return_body, headers: {})
+        stub_request(:get, "https://illiad.illiad/illiad/#{checkout}")
+          .with( headers: headers )
+          .to_return(status: 200, body: checkout_return_body, headers: {})
+          login_permanently_as username: 'PATRON2', patron_key: mock_user2
+      end
+
+      it 'includes Illiad materials in the summary counts' do
+        visit summaries_path
+        expect(page).to have_content 'Total checked out 5'
+        expect(page).to have_content '2 recalled'
+        expect(page).to have_content '3 overdue'
+        expect(page).to have_content 'Total holds 2'
+        expect(page).to have_content '1 ready for pickup'
+        expect(page).to have_content '1 not yet ready for pickup'
+      end
     end
   end
 end

--- a/spec/features/summaries_spec.rb
+++ b/spec/features/summaries_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Summaries' do
+  let(:headers) { {
+    'Apikey' => '1234',
+    'Connection' => 'close',
+    'Content-Type' => 'application/json',
+    'Host' => 'illiad.illiad',
+    'User-Agent' => 'http.rb/4.4.1'
+  } }
 
   after do
     Warden::Manager._on_request.clear
@@ -12,18 +19,11 @@ RSpec.describe 'Summaries' do
     context 'when there are no ILLiad checkouts or holds' do
       let(:mock_user) { 'patron1' }
       let(:return_body) { '[]' }
+
       before do
-          stub_request(:get, %r{https://illiad.illiad/illiad/ILLiadWebPlatform/Transaction/UserRequests})
-            .with(
-              headers: {
-                'Apikey' => '1234',
-                'Connection' => 'close',
-                'Content-Type' => 'application/json',
-                'Host' => 'illiad.illiad',
-                'User-Agent' => 'http.rb/4.4.1'
-              }
-            )
-            .to_return(status: 200, body: return_body, headers: {})
+        stub_request(:get, %r{https://illiad.illiad/illiad/ILLiadWebPlatform/Transaction/UserRequests})
+          .with(headers:)
+          .to_return(status: 200, body: return_body, headers: {})
         login_permanently_as username: 'PATRON1', patron_key: mock_user
       end
 
@@ -56,23 +56,31 @@ RSpec.describe 'Summaries' do
       end
       # patron2 below has 2 checkouts (1 recalled, 1 overdue) and no holds
       let(:mock_user2) { 'patron2' }
-      let(:hold) { "ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28TransactionStatus+eq+%27Awaiting+Copyright+Clearance%27+or+TransactionStatus+eq+%27Awaiting+Request+Processing%27+or+TransactionStatus+eq+%27Awaiting+Account+Validation%27+or+TransactionStatus+eq+%27In+Depth+Searching%27+or+TransactionStatus+eq+%27Awaiting+Reshare+Search%27+or+TransactionStatus+eq+%27UBorrow+Find+Item+Search%27+or+TransactionStatus+eq+%27Awaiting+RAPID+Request+Sending%27+or+TransactionStatus+eq+%27Awaiting+Post+Receipt+Processing%27+or+TransactionStatus+eq+%27Request+Sent%27+or+TransactionStatus+eq+%27In+Transit+to+Pickup+Location%27+or+TransactionStatus+eq+%27Customer+Notified+via+E-Mail%27+or+TransactionStatus+eq+%27Cancelled+by+Customer%27+or+TransactionStatus+eq+%27Duplicate+Request+Review%27+or+TransactionStatus+eq+%27Request+Available+Locally%27+or+TransactionStatus+eq+%27LST+TESTING%27or+%28startswith%28+TransactionStatus%2C+%27STAFF%27%29%29%29" }
-      let(:checkout) { "ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28%28TransactionStatus+eq+%27Checked+Out+to+Customer%27%29+or+%28TransactionStatus+eq+%27Awaiting+Recalled+Processing%27%29+or+%28TransactionStatus+eq+%27LST+TESTING%27%29+or+%28startswith%28+TransactionStatus%2C+%27Renewed+by%27%29%29%29" }
-      let(:headers) { {
-        'Apikey' => '1234',
-        'Connection' => 'close',
-        'Content-Type' => 'application/json',
-        'Host' => 'illiad.illiad',
-        'User-Agent' => 'http.rb/4.4.1'
-      } }
+      let(:hold) {
+        'ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28' \
+          'TransactionStatus+eq+%27Awaiting+Copyright+Clearance%27+or+TransactionStatus+eq+%27Awaiting+Request' \
+          '+Processing%27+or+TransactionStatus+eq+%27Awaiting+Account+Validation%27+or+TransactionStatus+eq+%27' \
+          'In+Depth+Searching%27+or+TransactionStatus+eq+%27Awaiting+Reshare+Search%27+or+TransactionStatus+eq' \
+          '+%27UBorrow+Find+Item+Search%27+or+TransactionStatus+eq+%27Awaiting+RAPID+Request+Sending%27+or+' \
+          'TransactionStatus+eq+%27Awaiting+Post+Receipt+Processing%27+or+TransactionStatus+eq+%27Request+Sent' \
+          '%27+or+TransactionStatus+eq+%27In+Transit+to+Pickup+Location%27+or+TransactionStatus+eq+%27Customer+' \
+          'Notified+via+E-Mail%27+or+TransactionStatus+eq+%27Cancelled+by+Customer%27+or+TransactionStatus+eq+' \
+          '%27Duplicate+Request+Review%27+or+TransactionStatus+eq+%27Request+Available+Locally%27+or+' \
+          'TransactionStatus+eq+%27LST+TESTING%27or+%28startswith%28+TransactionStatus%2C+%27STAFF%27%29%29%29' }
+      let(:checkout) {
+        'ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28%28' \
+          'TransactionStatus+eq+%27Checked+Out+to+Customer%27%29+or+%28TransactionStatus+eq+%27Awaiting+Recalled' \
+          '+Processing%27%29+or+%28TransactionStatus+eq+%27LST+TESTING%27%29+or+%28startswith%28+' \
+          'TransactionStatus%2C+%27Renewed+by%27%29%29%29' }
+
       before do
         stub_request(:get, "https://illiad.illiad/illiad/#{hold}")
-          .with( headers: headers )
+          .with(headers:)
           .to_return(status: 200, body: hold_return_body, headers: {})
         stub_request(:get, "https://illiad.illiad/illiad/#{checkout}")
-          .with( headers: headers )
+          .with(headers:)
           .to_return(status: 200, body: checkout_return_body, headers: {})
-          login_permanently_as username: 'PATRON2', patron_key: mock_user2
+        login_permanently_as username: 'PATRON2', patron_key: mock_user2
       end
 
       it 'includes Illiad materials in the summary counts' do

--- a/spec/services/illiad_response_spec.rb
+++ b/spec/services/illiad_response_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IlliadResponse do
+  subject(:response) { described_class.new('PATRON2') }
+
+  let(:hold_return_body) do
+    '[{"TransactionNumber":123456, "Username":"test123", "RequestType":"Loan",
+        "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 4",
+        "LoanPublisher":null, "LoanPlace":null, "TransactionStatus":"Awaiting Request Processing"},
+      {"TransactionNumber":123457, "Username":"test123", "RequestType":"Loan",
+        "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 5", "LoanPublisher":null,
+        "LoanPlace":null, "TransactionStatus":"Customer Notified via E-Mail"}]'
+  end
+  let(:checkout_return_body) do
+    '[{"TransactionNumber":123456, "Username":"test123", "RequestType":"Loan",
+       "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 1",
+       "LoanPublisher":null, "LoanPlace":null, "TransactionStatus":"Checked Out to Customer"},
+      {"TransactionNumber":123457, "Username":"test123", "RequestType":"Loan",
+        "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 2", "LoanPublisher":null,
+        "LoanPlace":null, "TransactionStatus":"Awaiting Recalled Processing", "DueDate":"2023-02-28T00:00:00"},
+      {"TransactionNumber":123457, "Username":"test123", "RequestType":"Loan",
+        "LoanAuthor":"Author, Test", "LoanTitle":"The Book Title 3", "LoanPublisher":null,
+        "LoanPlace":null, "TransactionStatus":"Checked Out to Customer"}]'
+  end
+  let(:hold) {
+    'ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28' \
+      'TransactionStatus+eq+%27Awaiting+Copyright+Clearance%27+or+TransactionStatus+eq+%27Awaiting+Request' \
+      '+Processing%27+or+TransactionStatus+eq+%27Awaiting+Account+Validation%27+or+TransactionStatus+eq+%27' \
+      'In+Depth+Searching%27+or+TransactionStatus+eq+%27Awaiting+Reshare+Search%27+or+TransactionStatus+eq' \
+      '+%27UBorrow+Find+Item+Search%27+or+TransactionStatus+eq+%27Awaiting+RAPID+Request+Sending%27+or+' \
+      'TransactionStatus+eq+%27Awaiting+Post+Receipt+Processing%27+or+TransactionStatus+eq+%27Request+Sent' \
+      '%27+or+TransactionStatus+eq+%27In+Transit+to+Pickup+Location%27+or+TransactionStatus+eq+%27Customer+' \
+      'Notified+via+E-Mail%27+or+TransactionStatus+eq+%27Cancelled+by+Customer%27+or+TransactionStatus+eq+' \
+      '%27Duplicate+Request+Review%27+or+TransactionStatus+eq+%27Request+Available+Locally%27+or+' \
+      'TransactionStatus+eq+%27LST+TESTING%27or+%28startswith%28+TransactionStatus%2C+%27STAFF%27%29%29%29' }
+  let(:checkout) {
+    'ILLiadWebPlatform/Transaction/UserRequests/PATRON2?$filter=%28RequestType+eq+%27Loan%27%29+and+%28%28' \
+      'TransactionStatus+eq+%27Checked+Out+to+Customer%27%29+or+%28TransactionStatus+eq+%27Awaiting+Recalled' \
+      '+Processing%27%29+or+%28TransactionStatus+eq+%27LST+TESTING%27%29+or+%28startswith%28+' \
+      'TransactionStatus%2C+%27Renewed+by%27%29%29%29' }
+  let(:headers) { {
+    'Apikey' => '1234',
+    'Connection' => 'close',
+    'Content-Type' => 'application/json',
+    'Host' => 'illiad.illiad',
+    'User-Agent' => 'http.rb/4.4.1'
+  } }
+
+  before do
+    stub_request(:get, "https://illiad.illiad/illiad/#{hold}")
+      .with(headers:)
+      .to_return(status: 200, body: hold_return_body, headers: {})
+    stub_request(:get, "https://illiad.illiad/illiad/#{checkout}")
+      .with(headers:)
+      .to_return(status: 200, body: checkout_return_body, headers: {})
+  end
+
+  describe '#illiad_holds' do
+    context 'when there are no holds found' do
+      before do
+        stub_request(:get, "https://illiad.illiad/illiad/#{hold}")
+          .with(headers:)
+          .to_return(status: 200, body: '[]', headers: {})
+      end
+
+      it 'returns an empty array' do
+        expect(response.illiad_holds).to eq []
+      end
+    end
+
+    context 'when there are holds found' do
+      it 'returns two holds' do
+        expect(response.illiad_holds.count).to eq 2
+      end
+    end
+  end
+
+  describe '#illiad_checkouts' do
+    context 'when there are no checkouts found' do
+      before do
+        stub_request(:get, "https://illiad.illiad/illiad/#{checkout}")
+          .with(headers:)
+          .to_return(status: 200, body: '[]', headers: {})
+      end
+
+      it 'returns an empty array' do
+        expect(response.illiad_checkouts).to eq []
+      end
+    end
+
+    context 'when there are checkouts found' do
+      it 'returns three checkouts' do
+        expect(response.illiad_checkouts.count).to eq 3
+      end
+    end
+  end
+
+  describe '#ill_recalled' do
+    it 'returns the number of recalled checkouts' do
+      expect(response.ill_recalled).to eq 1
+    end
+  end
+
+  describe '#ill_overdue' do
+    it 'returns the number of overdue checkouts' do
+      expect(response.ill_overdue).to eq 1
+    end
+  end
+
+  describe '#ill_ready_for_pickup' do
+    it 'returns the number of holds ready for pickup' do
+      expect(response.ill_ready_for_pickup).to eq 1
+    end
+  end
+end

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'summaries/index' do
   let(:fines) { [build(:fine)] }
   let(:patron_standing) { {} }
   let(:eligible_for_wage_garnishment) { false }
+  let(:illiad_response) { instance_double(IlliadResponse) }
   let(:patron) do
     instance_double(
       Patron,
@@ -29,9 +30,16 @@ RSpec.describe 'summaries/index' do
         helper_method :patron, :current_user?
     end
 
+    assign(:illiad_response, illiad_response)
+
     without_partial_double_verification {
       allow(view).to receive(:patron).and_return(patron)
       allow(view).to receive(:current_user?).and_return(true)
+      allow(illiad_response).to receive(:illiad_checkouts).and_return([])
+      allow(illiad_response).to receive(:illiad_holds).and_return([])
+      allow(illiad_response).to receive(:ill_recalled).and_return(0)
+      allow(illiad_response).to receive(:ill_overdue).and_return(0)
+      allow(illiad_response).to receive(:ill_ready_for_pickup).and_return(0)
     }
   end
 


### PR DESCRIPTION
Fixes #572 

Also fixes ILL hold bug: With Ruby 3 upgrade, positional vs keyword arguments were separated. This caused some errors with the SymphonyClientParser that were resolved.