### PR TITLE
'See all holds' button for Ill requests

### DIFF
--- a/app/views/holds/_results.html.erb
+++ b/app/views/holds/_results.html.erb
@@ -37,4 +37,4 @@
 <%= link_to 'Back to Catalog',
             "https://catalog.libraries.psu.edu/catalog/#{place_hold_catkey}",
             class: 'btn btn-info' %>
-<%= link_to 'See all Holds', holds_path, class: 'btn btn-info' %>
+<%= link_to t('myaccount.see_all_holds_button_text'), holds_path, class: 'btn btn-info' %>

--- a/app/views/ill/_results.html.erb
+++ b/app/views/ill/_results.html.erb
@@ -33,4 +33,4 @@
 <%= link_to 'Back to Catalog',
             "https://catalog.libraries.psu.edu/catalog/#{place_loan_result&.dig(:catkey)}",
             class: 'btn btn-info' %>
-<%= link_to 'See all Interlibrary loan requests', holds_path, class: 'btn btn-info' %>
+<%= link_to t('myaccount.see_all_holds_button_text'), holds_path, class: 'btn btn-info' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
       <p>Materials borrowed through <a href="http://www.libraries.psu.edu/mtss">MTSS</a> do not appear on this list and must be renewed separately.</p>
       <p>If you are finished with any items, please consider returning them to any Penn State library.</p>
     holds_info_html: Materials requested through <a href="http://www.libraries.psu.edu/mtss">MTSS</a> do not appear on this list and must be managed separately.
+    see_all_holds_button_text: See all holds 
     hold:
       cancel:
         success_html: <span class="font-weight-bold">Success!</span> %{bib_summary} was canceled.<br>

--- a/spec/views/ill/result.html.erb_spec.rb
+++ b/spec/views/ill/result.html.erb_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'ill/result.html.erb' do
   end
 
   it 'renders a link to Illiad requests' do
-    expect(rendered).to have_link 'See all Interlibrary loan requests', href: holds_path
+    expect(rendered).to have_link 'See all holds', href: holds_path
   end
 
   context 'when there is a successful loan result' do


### PR DESCRIPTION
Refactored 'See all holds' text into translation ymls.  Changed the ill results 'See all __' button to say 'See all holds'.

I couldn't get this page to load locally to double check that this works.  The tests pass, though.