### PR TITLE
Link to ILLiad when no ILL items

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,7 @@ RSpec/MultipleMemoizedHelpers:
     - 'spec/controllers/ill_controller_spec.rb'
     - 'spec/features/summaries_spec.rb'
     - 'spec/services/**/*'
+    - 'spec/views/summaries/index.html.erb_spec.rb'
 
 Rails/I18nLocaleTexts:
   Exclude:

--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -19,9 +19,14 @@
 
   <p>Library account record for <strong><%= patron.display_name %></strong></p>
 
-  <% if patron.checkouts.blank? && patron.holds.blank? && patron.fines.blank? && illiad_response.illiad_checkouts.blank? && illiad_response.illiad_holds.blank? %>
+  <% if illiad_response.illiad_checkouts.blank? && illiad_response.illiad_holds.blank? %>
+    <p>See and manage your <a href="<%= Settings.illiad.url %>">Interlibrary loans</a></p>
+    <% if patron.checkouts.blank? && patron.holds.blank? && patron.fines.blank? %>
       <p>You do not have any outstanding materials or bills.</p>
-  <% else %>
+    <% end %>
+  <% end %>
+
+  <% unless illiad_response.illiad_checkouts.blank? && illiad_response.illiad_holds.blank? && patron.checkouts.blank? && patron.holds.blank? && patron.fines.blank? %>
     <div class="row">
       <%= render DashboardItemComponent.new(model: 'Fines',
                                             count: patron.fines&.sum(&:owed_amount),

--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -20,7 +20,7 @@
   <p>Library account record for <strong><%= patron.display_name %></strong></p>
 
   <% if illiad_response.illiad_checkouts.blank? && illiad_response.illiad_holds.blank? %>
-    <p>See and manage your <a href="<%= Settings.illiad.url %>">Interlibrary loans</a></p>
+    <p>See and manage your <a href="<%= ill_manage_link(patron.library_ill_path_key) %>">Interlibrary loans</a></p>
     <% if patron.checkouts.blank? && patron.holds.blank? && patron.fines.blank? %>
       <p>You do not have any outstanding materials or bills.</p>
     <% end %>

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -95,8 +95,9 @@ RSpec.describe 'summaries/index' do
       it 'renders text for no materials and no bills and link to ILLiad' do
         render
 
-        expect(rendered).to
-        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).to include(
+          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+        )
         expect(rendered).to include('You do not have any outstanding materials or bills.')
       end
     end
@@ -109,8 +110,9 @@ RSpec.describe 'summaries/index' do
       it 'does not render text for no materials and no bills nor the link to ILLiad' do
         render
 
-        expect(rendered).not_to
-        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).not_to include(
+          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+        )
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
     end
@@ -129,8 +131,9 @@ RSpec.describe 'summaries/index' do
       it 'renders text for no materials and no bills and link to ILLiad' do
         render
 
-        expect(rendered).to
-        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).to include(
+          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+        )
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
     end
@@ -143,8 +146,9 @@ RSpec.describe 'summaries/index' do
       it 'does not render text for no materials and no bills nor the link to ILLiad' do
         render
 
-        expect(rendered).not_to
-        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).not_to include(
+          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+        )
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
     end

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'summaries/index' do
       holds: [],
       fines:,
       eligible_for_wage_garnishment?: eligible_for_wage_garnishment,
+      library_ill_path_key: 'upm',
       **patron_standing
     )
   end
@@ -96,7 +97,8 @@ RSpec.describe 'summaries/index' do
         render
 
         expect(rendered).to include(
-          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+          'See and manage your <a href="https://psu.illiad.oclc.org/illiad/upm/illiad.' \
+          'dll?Action=10&amp;Form=10">Interlibrary loans</a>'
         )
         expect(rendered).to include('You do not have any outstanding materials or bills.')
       end
@@ -111,7 +113,8 @@ RSpec.describe 'summaries/index' do
         render
 
         expect(rendered).not_to include(
-          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+          'See and manage your <a href="https://psu.illiad.oclc.org/illiad/upm/illiad.' \
+          'dll?Action=10&amp;Form=10">Interlibrary loans</a>'
         )
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
@@ -132,7 +135,8 @@ RSpec.describe 'summaries/index' do
         render
 
         expect(rendered).to include(
-          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+          'See and manage your <a href="https://psu.illiad.oclc.org/illiad/upm/illiad.' \
+          'dll?Action=10&amp;Form=10">Interlibrary loans</a>'
         )
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
@@ -147,7 +151,8 @@ RSpec.describe 'summaries/index' do
         render
 
         expect(rendered).not_to include(
-          '<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>'
+          'See and manage your <a href="https://psu.illiad.oclc.org/illiad/upm/illiad.' \
+          'dll?Action=10&amp;Form=10">Interlibrary loans</a>'
         )
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe 'summaries/index' do
       it 'renders text for no materials and no bills and link to ILLiad' do
         render
 
-        expect(rendered).to include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).to
+        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
         expect(rendered).to include('You do not have any outstanding materials or bills.')
       end
     end
@@ -104,11 +105,12 @@ RSpec.describe 'summaries/index' do
       before do
         allow(illiad_response).to receive(:illiad_holds).and_return [Object.new]
       end
-      
+
       it 'does not render text for no materials and no bills nor the link to ILLiad' do
         render
 
-        expect(rendered).not_to include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).not_to
+        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
     end
@@ -127,7 +129,8 @@ RSpec.describe 'summaries/index' do
       it 'renders text for no materials and no bills and link to ILLiad' do
         render
 
-        expect(rendered).to include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).to
+        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
     end
@@ -136,11 +139,12 @@ RSpec.describe 'summaries/index' do
       before do
         allow(illiad_response).to receive(:illiad_holds).and_return [Object.new]
       end
-      
+
       it 'does not render text for no materials and no bills nor the link to ILLiad' do
         render
 
-        expect(rendered).not_to include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
+        expect(rendered).not_to
+        include('<p>See and manage your <a href="https://illiad.illiad/illiad">Interlibrary loans</a></p>')
         expect(rendered).not_to include('You do not have any outstanding materials or bills.')
       end
     end


### PR DESCRIPTION
Adds text and link to ILLiad on summaries page when no ILL items.  Tests for this.

closes #641 