### PR TITLE
email fix

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -52,16 +52,19 @@ class CheckoutsController < ApplicationController
   end
 
   def export_checkouts_email
-    checkouts = []
-    raw_checkouts = params[:checkouts]
-    raw_checkouts.each do |checkout|
-      checkout_data = {
-        title: checkout[:title],
-        author: checkout[:author],
-        catkey: checkout[:catkey],
-        call_number: checkout[:call_number]
+    response = symphony_client.patron_info(patron_key: current_user.patron_key,
+                                           session_token: current_user.session_token,
+                                           item_details: { circRecordList: true })
+
+    patron = Patron.new(response)
+
+    checkouts = patron.checkouts.map do |c|
+      {
+        catkey: c.catkey,
+        title: c.title,
+        author: c.author,
+        call_number: c.call_number
       }
-      checkouts.push(checkout_data)
     end
 
     begin

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -45,7 +45,7 @@ class CheckoutsController < ApplicationController
       ris_string += tag_format('SN', checkout.identifier)
       ris_string += tag_format('Y2', Time.now.strftime('%Y-%m-%d'))
       ris_string += tag_format('ET', checkout.edition)
-      ris_string += 'ER  -\r\n'
+      ris_string += "ER  -\r\n"
     end
 
     send_data ris_string, filename: 'document.ris', type: :ris

--- a/app/views/checkouts/_checkouts_table.html.erb
+++ b/app/views/checkouts/_checkouts_table.html.erb
@@ -19,7 +19,7 @@
           </button>
           <div class="dropdown-menu" aria-labelledby="export-checkout-btn">
             <%= link_to 'RIS File', "#{Settings.catalog.bulk_ris_url}#{(checkouts.map { |c| c.catkey.to_s }).join(',')}", class: 'dropdown-item' %>
-            <%= link_to 'Email', export_checkouts_email_path(checkouts: checkouts.map { |c| { catkey: c.catkey, title: c.title, author: c.author, call_number: c.call_number } }), class: 'dropdown-item' %>
+            <%= link_to 'Email', export_checkouts_email_path, class: 'dropdown-item' %>
           </div>
         </span>
         <h2>Checkouts</h2>


### PR DESCRIPTION
removes checkout data as a param & instead makes a symphony call to get the data. This cleans up the url & fixes the issue where large numbers of checkout exports (70+) were failing to process

fixes ILL RIS bug- multiple checkouts were being sent as one large item because the new line wasn't registering in single quotes