### PR TITLE
rename app_env variable

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -2,5 +2,5 @@
 
 Bugsnag.configure do |config|
   config.app_version = ENV.fetch('APP_VERSION', nil)
-  config.release_stage = ENV.fetch('APP_ENV', 'development')
+  config.release_stage = ENV.fetch('BUGSNAG_RELEASE_STAGE', 'development')
 end


### PR DESCRIPTION
https://github.com/sidekiq/sidekiq/issues/4560

sidekiq uses the APP_ENV variable to mean the sidekiq app env, and overrides rails_env if set. 