### PR TITLE
remove engineering library while they are temporarily closed

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,7 +66,6 @@ illiad_locations:
   UP-BUSINES: Pattee Commons Services Desk
   UP-EDUBEHV: Pattee Commons Services Desk
   UP-EMS: Pattee Commons Services Desk
-  UP-ENGIN: Pattee Commons Services Desk
   UP-LIFESCI: Pattee Commons Services Desk
   UP-MAPS: Pattee Commons Services Desk
   UP-MEDICAL: Pattee Commons Services Desk
@@ -84,7 +83,6 @@ pickup_locations:
   DSL-CARL: 'Dickinson Law (Carlisle)'
   DSL-UP: 'Penn State Law (University Park)'
   UP-EMS: 'Earth & Mineral Science Library, 105 Deike'
-  UP-ENGIN: 'Engineering Library, 325 Hammond Building'
   UP-PAMS: 'Physical & Mathematical Science Library, 201 Davey Lab'
   UP-OFFICE: 'University Park Faculty/Staff/Graduate Student Office Delivery'
   ABINGTON: 'Penn State Abington'
@@ -140,7 +138,6 @@ pickup_locations_actual:
   UP-ARTSHUM: 'Arts & Humanities Library (Pattee)'
   UP-BUSINES: 'Business Library (Paterno)'
   UP-EMS: 'Earth & Mineral Science Library, 105 Deike'
-  UP-ENGIN: 'Engineering Library, 325 Hammond Building'
   UP-LIFESCI: 'Life Sciences Library (Paterno)'
   UP-MAPS: 'Maps and Geospatial Information (Pattee)'
   UP-MEDICAL: 'College of Medicine (UP)'


### PR DESCRIPTION
removes them from the pickup location dropdown 