### PR TITLE
Add error handling to Bugsnag for specific Rails actions

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,4 +3,10 @@
 Bugsnag.configure do |config|
   config.app_version = ENV.fetch('APP_VERSION', nil)
   config.release_stage = ENV.fetch('BUGSNAG_RELEASE_STAGE', 'development')
+
+  config.add_on_error(proc do |event|
+    action = event.request&.dig(:railsAction)
+
+    event.ignore! if action&.start_with?('ok_computer')
+  end)
 end


### PR DESCRIPTION
This pull request updates the Bugsnag configuration to prevent error reporting for certain internal health check actions. The main change is the addition of a filter that ignores errors triggered by requests whose action starts with "ok_computer".

Error filtering:

* Updated `config/initializers/bugsnag.rb` to add a filter that ignores errors for requests where the action starts with "ok_computer", preventing unnecessary error reports from health check endpoints.
This pull request introduces an improvement to our Bugsnag error reporting configuration. The main change is to prevent errors triggered by health check actions (specifically those starting with `ok_computer`) from being reported to Bugsnag, which helps reduce noise in our error tracking.

Error reporting improvements:

* Updated `config/initializers/bugsnag.rb` to ignore errors for requests where the `railsAction` starts with `ok_computer`, preventing health check errors from being reported to Bugsnag.