### PR TITLE
Update CI configuration: change CI_UTILS_IMAGE_TAG to v4.6.4, add CLU…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
   CI_UTILS_IMAGE_TAG:
     type: string
-    default: "v4.3.0"
+    default: "v4.6.4"
   CONFIG_REPO_NAME:
     type: string
     default: "myaccount-config"
@@ -35,6 +35,12 @@ parameters:
   CLUSTERS_PROD:
     type: string
     default: "prod"
+  CLUSTERS_ULPROD:
+    type: string
+    default: "ulprod"
+  PIPELINE_CONFIG_VERSION:
+    type: string
+    default: "1.0.1"
 
 commands:
   clone-config-repo:
@@ -201,17 +207,15 @@ jobs:
       CONFIG_REPO_URL: << pipeline.parameters.CONFIG_REPO_URL >>
       CONFIG_REPO: << pipeline.parameters.CONFIG_REPO_URL >>
       REGISTRY_HOST: << pipeline.parameters.REGISTRY_HOST >>
+      REGISTRY_REPO: "myaccount"
+      TO_YAML_TAG_TARGET: ".spec.source.helm.values.image.tag"
+      PIPELINE_CONFIG_VERSION: << pipeline.parameters.PIPELINE_CONFIG_VERSION >>
     steps:
       - clone-config-repo
       - run:
           name: Tag & Release Image
           command: |
-            export CONFIG_REPO="$CONFIG_REPO_URL"
-            export TRIGGERED_BY="$CIRCLE_USERNAME"
-            export REGISTRY_REPO="$CIRCLE_PROJECT_REPONAME"
-            /usr/local/bin/image-tag
-            cd $CONFIG_REPO_NAME
-            /usr/local/bin/image-release-pr clusters/prod/manifests/$CIRCLE_PROJECT_REPONAME/prod.yaml
+            /usr/local/bin/image-release-for-clusters
 
   test-application:
     executor:
@@ -278,7 +282,7 @@ workflows:
           delete_branch: << pipeline.parameters.GHA_Meta >>
           filters:
             branches:
-              only: main
+              only: /.*/
 
   docker-push:
     unless:
@@ -318,7 +322,7 @@ workflows:
             - test-application
       - release-image:
           name: release-image
-          clusters: << pipeline.parameters.CLUSTERS_PROD >>
+          clusters: << pipeline.parameters.CLUSTERS_PROD >>,<< pipeline.parameters.CLUSTERS_ULPROD >>
           context:
             - org-global
           from_tag: "<< pipeline.git.revision >>"

--- a/.github/workflows/delete-branch-deployment.yml
+++ b/.github/workflows/delete-branch-deployment.yml
@@ -1,0 +1,14 @@
+name: Branch Deleted
+on:
+  delete
+jobs:
+  delete-deployment:
+    if: contains(github.event.ref, 'update/') || contains(github.event.ref, 'preview/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CircleCI Pipeline
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
+        with:
+          GHA_Meta: "${{ github.event.ref }}"
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
This pull request updates the CI/CD pipeline configuration to support new deployment clusters, improve release automation, and add GitHub Actions integration for branch deletion events. The changes enhance deployment flexibility, streamline image release processes, and improve workflow automation.

**Pipeline parameter and deployment improvements:**

* Added new parameters `CLUSTERS_ULPROD` and `PIPELINE_CONFIG_VERSION` to `.circleci/config.yml` to support deployments to an additional cluster and allow versioning of pipeline configuration.
* Updated the `release-image` workflow to deploy to both `CLUSTERS_PROD` and the new `CLUSTERS_ULPROD` clusters, enabling multi-cluster deployments.

**Release process enhancements:**

* Updated the default `CI_UTILS_IMAGE_TAG` to `v4.6.4` for improved CI utilities.
* Simplified the image release job by replacing the manual tagging and release commands with a single `/usr/local/bin/image-release-for-clusters` command, and set new environment variables for image release.

**Workflow automation and integration:**

* Added a new GitHub Actions workflow (`.github/workflows/delete-branch-deployment.yml`) to trigger a CircleCI pipeline when branches matching `update/` or `preview/` are deleted, automating cleanup tasks.
* Modified branch filters in CircleCI workflows to run on all branches instead of only `main`, increasing workflow coverage.…STERS_ULPROD parameter, and modify release-image workflow to include ULPROD cluster. Add GitHub workflow for branch deletion to trigger CircleCI pipeline.